### PR TITLE
Add pep631 imports

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -31,10 +31,9 @@ jobs:
         echo ${{ github.ref }}
         make test-pytest
 
-
   build:
     needs: test
-    if: success() && github.ref == 'refs/heads/master'
+    if: success() && startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -56,7 +55,6 @@ jobs:
   publish-to-pypi:
     name: >-
       Publish Python 🐍 distribution 📦 to PyPI
-    if: success() && startsWith(github.ref, 'refs/tags/v')
     needs:
       - build
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,23 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-## [0.9.0] - 2024-06-22
-Initial release
+## [0.10.0] - 2024-06-25 - PEP-631 support
+### Added
+- Support PEP-631 style dependencies
 
+### Changes
+- Remove `--config-file` option: Always use the `pyprojec.toml` file associated with the source
+- Renames in `pyproject.toml` section `tool.check_dependencies`:
+  - `ignore-requirements` to `known-missing` 
+  - `extra-requirements` to `known-extra` 
+- Rename CLI options:
+  - `--extra` to `--missing`
+  - `--ignore` to `--extra`
+
+
+## [0.9.1] - 2024-06-24 - Continuous Integration
+### Added
+- Github actions for automated testing and publishing
+
+## [0.9.0] - 2024-06-22 - Hello World!
+Initial version of the package

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changes
 - Remove `--config-file` option: Always use the `pyprojec.toml` file associated with the source
 - Renames in `pyproject.toml` section `tool.check_dependencies`:
-  - `ignore-requirements` to `known-missing` 
-  - `extra-requirements` to `known-extra` 
+  - `ignore-requirements` to `known-missing`
+  - `extra-requirements` to `known-extra`
 - Rename CLI options:
   - `--extra` to `--missing`
   - `--ignore` to `--extra`

--- a/poetry.lock
+++ b/poetry.lock
@@ -234,38 +234,38 @@ files = [
 
 [[package]]
 name = "mypy"
-version = "1.10.0"
+version = "1.10.1"
 description = "Optional static typing for Python"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "mypy-1.10.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:da1cbf08fb3b851ab3b9523a884c232774008267b1f83371ace57f412fe308c2"},
-    {file = "mypy-1.10.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:12b6bfc1b1a66095ab413160a6e520e1dc076a28f3e22f7fb25ba3b000b4ef99"},
-    {file = "mypy-1.10.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9e36fb078cce9904c7989b9693e41cb9711e0600139ce3970c6ef814b6ebc2b2"},
-    {file = "mypy-1.10.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:2b0695d605ddcd3eb2f736cd8b4e388288c21e7de85001e9f85df9187f2b50f9"},
-    {file = "mypy-1.10.0-cp310-cp310-win_amd64.whl", hash = "sha256:cd777b780312ddb135bceb9bc8722a73ec95e042f911cc279e2ec3c667076051"},
-    {file = "mypy-1.10.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3be66771aa5c97602f382230165b856c231d1277c511c9a8dd058be4784472e1"},
-    {file = "mypy-1.10.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:8b2cbaca148d0754a54d44121b5825ae71868c7592a53b7292eeb0f3fdae95ee"},
-    {file = "mypy-1.10.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1ec404a7cbe9fc0e92cb0e67f55ce0c025014e26d33e54d9e506a0f2d07fe5de"},
-    {file = "mypy-1.10.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:e22e1527dc3d4aa94311d246b59e47f6455b8729f4968765ac1eacf9a4760bc7"},
-    {file = "mypy-1.10.0-cp311-cp311-win_amd64.whl", hash = "sha256:a87dbfa85971e8d59c9cc1fcf534efe664d8949e4c0b6b44e8ca548e746a8d53"},
-    {file = "mypy-1.10.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:a781f6ad4bab20eef8b65174a57e5203f4be627b46291f4589879bf4e257b97b"},
-    {file = "mypy-1.10.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b808e12113505b97d9023b0b5e0c0705a90571c6feefc6f215c1df9381256e30"},
-    {file = "mypy-1.10.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8f55583b12156c399dce2df7d16f8a5095291354f1e839c252ec6c0611e86e2e"},
-    {file = "mypy-1.10.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:4cf18f9d0efa1b16478c4c129eabec36148032575391095f73cae2e722fcf9d5"},
-    {file = "mypy-1.10.0-cp312-cp312-win_amd64.whl", hash = "sha256:bc6ac273b23c6b82da3bb25f4136c4fd42665f17f2cd850771cb600bdd2ebeda"},
-    {file = "mypy-1.10.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:9fd50226364cd2737351c79807775136b0abe084433b55b2e29181a4c3c878c0"},
-    {file = "mypy-1.10.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:f90cff89eea89273727d8783fef5d4a934be2fdca11b47def50cf5d311aff727"},
-    {file = "mypy-1.10.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fcfc70599efde5c67862a07a1aaf50e55bce629ace26bb19dc17cece5dd31ca4"},
-    {file = "mypy-1.10.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:075cbf81f3e134eadaf247de187bd604748171d6b79736fa9b6c9685b4083061"},
-    {file = "mypy-1.10.0-cp38-cp38-win_amd64.whl", hash = "sha256:3f298531bca95ff615b6e9f2fc0333aae27fa48052903a0ac90215021cdcfa4f"},
-    {file = "mypy-1.10.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:fa7ef5244615a2523b56c034becde4e9e3f9b034854c93639adb667ec9ec2976"},
-    {file = "mypy-1.10.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:3236a4c8f535a0631f85f5fcdffba71c7feeef76a6002fcba7c1a8e57c8be1ec"},
-    {file = "mypy-1.10.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4a2b5cdbb5dd35aa08ea9114436e0d79aceb2f38e32c21684dcf8e24e1e92821"},
-    {file = "mypy-1.10.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:92f93b21c0fe73dc00abf91022234c79d793318b8a96faac147cd579c1671746"},
-    {file = "mypy-1.10.0-cp39-cp39-win_amd64.whl", hash = "sha256:28d0e038361b45f099cc086d9dd99c15ff14d0188f44ac883010e172ce86c38a"},
-    {file = "mypy-1.10.0-py3-none-any.whl", hash = "sha256:f8c083976eb530019175aabadb60921e73b4f45736760826aa1689dda8208aee"},
-    {file = "mypy-1.10.0.tar.gz", hash = "sha256:3d087fcbec056c4ee34974da493a826ce316947485cef3901f511848e687c131"},
+    {file = "mypy-1.10.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e36f229acfe250dc660790840916eb49726c928e8ce10fbdf90715090fe4ae02"},
+    {file = "mypy-1.10.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:51a46974340baaa4145363b9e051812a2446cf583dfaeba124af966fa44593f7"},
+    {file = "mypy-1.10.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:901c89c2d67bba57aaaca91ccdb659aa3a312de67f23b9dfb059727cce2e2e0a"},
+    {file = "mypy-1.10.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:0cd62192a4a32b77ceb31272d9e74d23cd88c8060c34d1d3622db3267679a5d9"},
+    {file = "mypy-1.10.1-cp310-cp310-win_amd64.whl", hash = "sha256:a2cbc68cb9e943ac0814c13e2452d2046c2f2b23ff0278e26599224cf164e78d"},
+    {file = "mypy-1.10.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:bd6f629b67bb43dc0d9211ee98b96d8dabc97b1ad38b9b25f5e4c4d7569a0c6a"},
+    {file = "mypy-1.10.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a1bbb3a6f5ff319d2b9d40b4080d46cd639abe3516d5a62c070cf0114a457d84"},
+    {file = "mypy-1.10.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b8edd4e9bbbc9d7b79502eb9592cab808585516ae1bcc1446eb9122656c6066f"},
+    {file = "mypy-1.10.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:6166a88b15f1759f94a46fa474c7b1b05d134b1b61fca627dd7335454cc9aa6b"},
+    {file = "mypy-1.10.1-cp311-cp311-win_amd64.whl", hash = "sha256:5bb9cd11c01c8606a9d0b83ffa91d0b236a0e91bc4126d9ba9ce62906ada868e"},
+    {file = "mypy-1.10.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:d8681909f7b44d0b7b86e653ca152d6dff0eb5eb41694e163c6092124f8246d7"},
+    {file = "mypy-1.10.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:378c03f53f10bbdd55ca94e46ec3ba255279706a6aacaecac52ad248f98205d3"},
+    {file = "mypy-1.10.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6bacf8f3a3d7d849f40ca6caea5c055122efe70e81480c8328ad29c55c69e93e"},
+    {file = "mypy-1.10.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:701b5f71413f1e9855566a34d6e9d12624e9e0a8818a5704d74d6b0402e66c04"},
+    {file = "mypy-1.10.1-cp312-cp312-win_amd64.whl", hash = "sha256:3c4c2992f6ea46ff7fce0072642cfb62af7a2484efe69017ed8b095f7b39ef31"},
+    {file = "mypy-1.10.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:604282c886497645ffb87b8f35a57ec773a4a2721161e709a4422c1636ddde5c"},
+    {file = "mypy-1.10.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:37fd87cab83f09842653f08de066ee68f1182b9b5282e4634cdb4b407266bade"},
+    {file = "mypy-1.10.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8addf6313777dbb92e9564c5d32ec122bf2c6c39d683ea64de6a1fd98b90fe37"},
+    {file = "mypy-1.10.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:5cc3ca0a244eb9a5249c7c583ad9a7e881aa5d7b73c35652296ddcdb33b2b9c7"},
+    {file = "mypy-1.10.1-cp38-cp38-win_amd64.whl", hash = "sha256:1b3a2ffce52cc4dbaeee4df762f20a2905aa171ef157b82192f2e2f368eec05d"},
+    {file = "mypy-1.10.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:fe85ed6836165d52ae8b88f99527d3d1b2362e0cb90b005409b8bed90e9059b3"},
+    {file = "mypy-1.10.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:c2ae450d60d7d020d67ab440c6e3fae375809988119817214440033f26ddf7bf"},
+    {file = "mypy-1.10.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6be84c06e6abd72f960ba9a71561c14137a583093ffcf9bbfaf5e613d63fa531"},
+    {file = "mypy-1.10.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:2189ff1e39db399f08205e22a797383613ce1cb0cb3b13d8bcf0170e45b96cc3"},
+    {file = "mypy-1.10.1-cp39-cp39-win_amd64.whl", hash = "sha256:97a131ee36ac37ce9581f4220311247ab6cba896b4395b9c87af0675a13a755f"},
+    {file = "mypy-1.10.1-py3-none-any.whl", hash = "sha256:71d8ac0b906354ebda8ef1673e5fde785936ac1f29ff6987c7483cfbd5a4235a"},
+    {file = "mypy-1.10.1.tar.gz", hash = "sha256:1f8f492d7db9e3593ef42d4f115f04e556130f2819ad33ab84551403e97dd4c0"},
 ]
 
 [package.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "check-dependencies"
-version = "0.9.1"
+version = "0.10.0"
 description = ""
 authors = ["Micha Scholl <schollm-git@gmx.com>"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "check-dependencies"
-version = "0.9.0"
+version = "0.9.1"
 description = ""
 authors = ["Micha Scholl <schollm-git@gmx.com>"]
 readme = "README.md"

--- a/src/check_dependencies/__main__.py
+++ b/src/check_dependencies/__main__.py
@@ -4,7 +4,7 @@ import argparse
 import logging
 import sys
 
-from check_dependencies.lib import Config
+from check_dependencies.lib import AppConfig
 from check_dependencies.main import yield_wrong_imports
 
 logging.basicConfig(
@@ -26,14 +26,6 @@ parser.add_argument(
     "file_name", type=str, nargs="+", help="Python Source file to analyse"
 )
 parser.add_argument(
-    "--config-file",
-    type=str,
-    required=False,
-    default="",
-    help="Location of pyproject.toml file, can be file or a directory"
-    " containing pyproject.toml file",
-)
-parser.add_argument(
     "--include-dev",
     action="store_true",
     default=False,
@@ -52,28 +44,27 @@ parser.add_argument(
     help="Show all imports (including correct ones)",
 )
 parser.add_argument(
-    "--extra",
+    "--missing",
     type=str,
-    help="Comma seperated list of extra requirements."
+    help="Comma seperated list of requirements known to be missing."
     " Assume they are part of the requirements",
     default="",
 )
 parser.add_argument(
-    "--ignore",
+    "--extra",
     type=str,
-    help="Comma seperated list of requirements to ignore."
+    help="Comma seperated list of requirements known to not be imported."
     " Assume they are not part of the requirements",
     default="",
 )
 args = parser.parse_args()
 
-cfg = Config(
-    file=args.config_file,
+cfg = AppConfig(
     include_dev=args.include_dev,
     verbose=args.verbose,
     show_all=args.all,
-    extra_requirements=args.extra.split(","),
-    ignore_requirements=args.ignore.split(","),
+    known_extra=set(args.extra.split(",")),
+    known_missing=set(args.missing.split(",")),
 )
 
 wrong_import_lines = yield_wrong_imports(args.file_name, cfg)

--- a/src/check_dependencies/builtin_module.py
+++ b/src/check_dependencies/builtin_module.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 
 import sys
 
-BUILTINS: set[str]
+BUILTINS: frozenset[str]
 if sys.version_info >= (3, 10):
-    BUILTINS = set(sys.stdlib_module_names)  # pylint: disable=no-member
+    BUILTINS = frozenset(sys.stdlib_module_names)  # pylint: disable=no-member
 else:
     # Use the list of builtins from Python 3.9
-    BUILTINS = set(
+    BUILTINS = frozenset(
         """\
 __future__
 _abc

--- a/src/check_dependencies/main.py
+++ b/src/check_dependencies/main.py
@@ -4,79 +4,92 @@ from __future__ import annotations
 
 import ast
 import logging
+from os.path import commonpath
 from pathlib import Path
 from typing import Generator, Iterator, Sequence
 
 from check_dependencies.builtin_module import BUILTINS
-from check_dependencies.lib import Config, Dependency, pkg
+from check_dependencies.lib import AppConfig, Dependency, PyProjectToml, pkg
 
 logger = logging.getLogger("check_dependencies")
+ERR_MISSING_DEPENDENCY = 2
+ERR_EXTRA_DEPENDENCY = 4
+ERR_NO_PYPROJECT = 8
 
 
 def yield_wrong_imports(
-    file_names: Sequence[str], cfg: Config
+    file_names: Sequence[str], app_cfg: AppConfig
 ) -> Generator[str, None, int]:
     """Yield output lines of missing/unused imports (or all imports in case of cfg.show_all)"""
-    declared_deps = cfg.get_declared_dependencies()
     used_deps: set[str] = set()
-    missing_fmt = cfg.mk_src_formatter()
+    src_fmt = app_cfg.mk_src_formatter()
+    try:
+        pyproject_candidate = Path(
+            commonpath(Path(p).expanduser().resolve() for p in file_names)
+        )
+    except ValueError as exc:
+        logger.fatal("Could not find pyproject.toml in common path: %s", exc)
+        return ERR_NO_PYPROJECT
+
+    src_cfg = PyProjectToml.from_pyproject(pyproject_candidate, app_cfg=app_cfg)
     exit_status = 0
-    for file_name in _collect_files(file_names):
+
+    expected_dependencies = frozenset().union(
+        src_cfg.dependencies,  # dependencies from pyproject.toml
+        BUILTINS,  # builtins
+    )
+    allowed_dependencies = frozenset().union(
+        expected_dependencies, app_cfg.known_missing, src_cfg.known_missing
+    )
+
+    for src_pth in _collect_files(file_names):
         for cause, module, stmt in _missing_imports_iter(
-            Path(file_name),
-            declared_deps | BUILTINS | set(cfg.extra_requirements),
-            seen=used_deps,
+            src_pth, dependencies=allowed_dependencies
         ):
             if cause != Dependency.OK:
-                exit_status |= 2
+                exit_status |= ERR_MISSING_DEPENDENCY
             used_deps.add(pkg(module))
-            if f := missing_fmt(file_name, cause, module, stmt):
-                yield f
+            yield from src_fmt(src_pth, cause, module, stmt)
 
-    if cfg.file:
-        unused_fmt = cfg.mk_unused_formatter()
-        errs = [
-            err
-            for dep in sorted(declared_deps - used_deps - set(cfg.ignore_requirements))
-            if (err := unused_fmt(dep))
-        ]
-        if errs:
-            exit_status |= 4
-            if cfg.verbose:
-                yield ""
-                yield "### Dependencies in config file not used in application:"
-                yield f"# Config file: {cfg.file}"
-            yield from errs
+    if superfluous_requirements := [
+        msg
+        for dep in sorted(
+            src_cfg.dependencies.difference(
+                used_deps, app_cfg.known_extra, src_cfg.known_extra
+            )
+        )
+        for msg in app_cfg.unused_fmt(dep)
+    ]:
+        exit_status |= ERR_EXTRA_DEPENDENCY
+        if app_cfg.verbose:
+            yield ""
+            yield "### Dependencies in config file not used in application:"
+            yield f"# Config file: {src_cfg.file}"
+        yield from superfluous_requirements
     return exit_status
 
 
-def _collect_files(file_names: Sequence[str]) -> Iterator[str]:
+def _collect_files(file_names: Sequence[str]) -> Iterator[Path]:
     """
     Collect all Python files in a list of files or directories.
     Ensure no file is visited more than once
     """
-    seen = set()
+    visited = set()
     for p in map(Path, file_names):
-        if (p_resolved := p.resolve()) in seen:
-            continue
-        seen.add(p_resolved)
-        if p.is_dir():
-            for p_sub in p.rglob("*.py"):
-                if (p_sub_resolved := p_sub.resolve()) in seen:
-                    continue
-                seen.add(p_sub_resolved)
-                yield p_sub.as_posix()
-        else:
-            yield p.as_posix()
+        for p_sub in p.rglob("*.py") if p.is_dir() else [p]:
+            if (p_sub_resolved := p_sub.resolve()) in visited:
+                continue
+            visited.add(p_sub_resolved)
+            yield p_sub
 
 
 def _missing_imports_iter(
-    file: Path, dependencies: set[str], seen: set[str]
+    file: Path, dependencies: set[str]
 ) -> Iterator[tuple[Dependency, str, ast.stmt]]:
     """
     Find missing imports in a Python file
     :param file: Pyton file to analyse
-    :param dependencies: Declared dependencies
+    :param dependencies: Declared dependencies from pyproject file
     :param seen: Cache of seen packages - this is changed during the iteration
     :yields: Tuple of status, module name and optional import statement
     """
@@ -88,7 +101,6 @@ def _missing_imports_iter(
     for module, stmt in _imports_iter(parsed.body):
         pkg_ = pkg(module)
         status = Dependency.OK if pkg_ in dependencies else Dependency.NA
-        seen.add(pkg_)
         yield status, module, stmt
 
 

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -2,6 +2,8 @@
 
 from pathlib import Path
 
+import pytest
+
 DATA = Path(__file__).parent / "data"
 try:
     DATA = DATA.resolve().relative_to(Path().resolve())
@@ -9,6 +11,20 @@ except ValueError:
     pass
 
 SRC = (DATA / "src.py").as_posix()
+PEP631 = DATA / "pyproject_pep631.toml"
+PEP631_EXTRA = DATA / "pyproject_pep631_extra.toml"
+POETRY = DATA / "pyproject_poetry.toml"
+POETRY_EXTRA = DATA / "pyproject_poetry_extra.toml"
+PYPROJECT_CFG = DATA / "pyproject_cfg.toml"
 
-POETRY = (DATA / "pyproject_poetry_test.toml").as_posix()
-POETRY_EXTRA = (DATA / "pyproject_poetry_extra.toml").as_posix()
+
+@pytest.fixture(params=[PEP631, POETRY])
+def pyproject(request):
+    """Fixture for testing pyproject.toml files"""
+    return request.param
+
+
+@pytest.fixture(params=[PEP631_EXTRA, POETRY_EXTRA])
+def pyproject_extra(request):
+    """Fixture for testing extra requirements"""
+    return request.param

--- a/src/tests/data/pyproject_cfg.toml
+++ b/src/tests/data/pyproject_cfg.toml
@@ -1,0 +1,15 @@
+[project]
+name = "check-dependencies"
+dependencies = [
+    "test_main > 0",
+    # "test_1 < 2",
+    "test_extra > 99"  # to be ignored
+]
+
+[tool.check-dependencies]
+known-extra = [
+    "test_extra"
+]
+known-missing = [
+    "test_1", "missing", "missing_class", "missing_def"
+]

--- a/src/tests/data/pyproject_pep631.toml
+++ b/src/tests/data/pyproject_pep631.toml
@@ -1,0 +1,9 @@
+[project]
+name = "check-dependencies"
+dependencies = [
+    "test_main > 0",
+    "test_1 < 2",
+]
+[project.optional-dependencies]
+test_optional = [
+]

--- a/src/tests/data/pyproject_pep631_extra.toml
+++ b/src/tests/data/pyproject_pep631_extra.toml
@@ -1,0 +1,10 @@
+[project]
+name = "check-dependencies"
+dependencies = [
+    "test_main > 0",
+    "test_1 < 2"
+]
+[project.optional-dependencies]
+test_optional = [
+    "test_extra > 0"
+]

--- a/src/tests/data/pyproject_poetry.toml
+++ b/src/tests/data/pyproject_poetry.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-name = "dependency-check-test"
+name = "check-dependencies"
 
 [tool.poetry.dependencies]
 python = "^3.8"

--- a/src/tests/data/pyproject_poetry_extra.toml
+++ b/src/tests/data/pyproject_poetry_extra.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-name = "dependency-check-test"
+name = "check-dependencies"
 
 [tool.poetry.dependencies]
 python = "^3.8"

--- a/src/tests/data/src.py
+++ b/src/tests/data/src.py
@@ -1,10 +1,11 @@
 # pylint: skip-file
-import dependency_check_test
 import missing.bar
 import missing.foo
 import test_1
 import test_main  # This is a test import provided by the test environment
 from missing import baz
+
+import check_dependencies
 
 
 class X:

--- a/src/tests/test_builtin_modules.py
+++ b/src/tests/test_builtin_modules.py
@@ -7,7 +7,7 @@ from check_dependencies.builtin_module import BUILTINS
 
 def test_is_set():
     """Are the builtin modules stored in a set?"""
-    assert isinstance(BUILTINS, set)
+    assert isinstance(BUILTINS, frozenset)
 
 
 def test_contains_future():


### PR DESCRIPTION
- Remove `--config-file` option: Always use the `pyprojec.toml` file associated with the source
- Renames in `pyproject.toml` section `tool.check_dependencies`:
  - `ignore-requirements` to `known-missing`
  - `extra-requirements` to `known-extra`
- Rename CLI options:
  - `--extra` to `--missing`
  - `--ignore` to `--extra`