### PR TITLE
Auto detect dependency mapping

### DIFF
--- a/src/check_dependencies/mapping.py
+++ b/src/check_dependencies/mapping.py
@@ -45,23 +45,22 @@ class DependencyMapping:
     import_names: tuple[str]
 
 
-def find_smallest_valid_index(indices: list[int]) -> int:
-    valid_indices = [index for index in indices if index != -1]
-    return min(valid_indices)
-
-
 def create_mapping(pip_name: str, record_content: str) -> DependencyMapping:
     import_names: set[str] = set()
     for line in record_content.split("\n"):
         line = line.strip()
         if line != "":
-            first_slash = line.find("/")
-            first_dotpy = line.find(".py")
-            potential_import_name = line[
-                : find_smallest_valid_index([first_slash, first_dotpy])
-            ]
-            if not potential_import_name.endswith(".dist-info"):
-                import_names.add(potential_import_name)
+            if "/" in line:
+                line = line[: line.find("/")]
+            if "\\" in line:
+                line = line[: line.find("\\")]
+            if line.endswith(".dist-info"):
+                continue
+
+            if "." in line:
+                line = line[: line.find(".")]
+            if line != "":
+                import_names.add(line)
     return DependencyMapping(pip_name, tuple(sorted(import_names)))
 
 
@@ -85,12 +84,8 @@ def gather_dependency_mappings(
     return mappings
 
 
-def gather_venv_mappings(
-    project_id: str, venv: Path
-) -> set[DependencyMapping]:
-    venv_config = parse_venv_config(
-        (venv / "pyvenv.cfg").read_text()
-    )
+def gather_venv_mappings(project_id: str, venv: Path) -> set[DependencyMapping]:
+    venv_config = parse_venv_config((venv / "pyvenv.cfg").read_text())
     mappings = gather_dependency_mappings(project_id, venv / "Lib" / "site-packages")
     if venv_config.include_base_site_packages:
         mappings.update(

--- a/src/check_dependencies/mapping.py
+++ b/src/check_dependencies/mapping.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from re import Pattern
+
+_home_path_regex: Pattern[str] = re.compile(r"^home\s=\s(?P<home>.*)$", re.MULTILINE)
+_include_system_site_packages_regex: Pattern[str] = re.compile(
+    r"^include-system-site-packages\s=\s(?P<include_system_site_packages>.*)$",
+    re.MULTILINE,
+)
+
+
+@dataclass(frozen=True)
+class VenvConfig:
+    base_installation_path: Path
+    include_base_site_packages: bool
+
+
+def parse_venv_config(file_content: str) -> VenvConfig:
+    home_match = re.search(_home_path_regex, file_content)
+    if home_match is None:
+        raise RuntimeError("Could not parse `home` property from venv config")
+    include_system_site_packages_match = re.search(
+        _include_system_site_packages_regex, file_content
+    )
+    if include_system_site_packages_match is None:
+        raise RuntimeError(
+            "Could not parse `include-system-site-packages` property from venv config"
+        )
+    return VenvConfig(
+        base_installation_path=Path(home_match.group("home")),
+        include_base_site_packages=include_system_site_packages_match.group(
+            "include_system_site_packages"
+        ).lower()
+        == "true",
+    )
+
+
+@dataclass(frozen=True)
+class DependencyMapping:
+    pip_name: str
+    import_names: tuple[str]
+
+
+def find_smallest_valid_index(indices: list[int]) -> int:
+    valid_indices = [index for index in indices if index != -1]
+    return min(valid_indices)
+
+
+def create_mapping(pip_name: str, record_content: str) -> DependencyMapping:
+    import_names: set[str] = set()
+    for line in record_content.split("\n"):
+        line = line.strip()
+        if line != "":
+            first_slash = line.find("/")
+            first_dotpy = line.find(".py")
+            potential_import_name = line[
+                : find_smallest_valid_index([first_slash, first_dotpy])
+            ]
+            if not potential_import_name.endswith(".dist-info"):
+                import_names.add(potential_import_name)
+    return DependencyMapping(pip_name, tuple(sorted(import_names)))
+
+
+def get_package_name_from_directory(directory_name: str) -> str:
+    return directory_name[: directory_name.find("-")]
+
+
+def gather_dependency_mappings(
+    project_id: str, directory: Path
+) -> set[DependencyMapping]:
+    mappings: set[DependencyMapping] = set()
+    for meta_directory in directory.glob("*.dist-info/"):
+        # is_dir(): guard against bug pre py11: https://docs.python.org/3.11/whatsnew/3.11.html#pathlib
+        if meta_directory.is_dir() and not meta_directory.name.startswith(project_id):
+            mappings.add(
+                create_mapping(
+                    get_package_name_from_directory(meta_directory.name),
+                    (meta_directory / "RECORD").read_text(),
+                )
+            )
+    return mappings
+
+
+def gather_venv_mappings(
+    project_id: str, venv: Path
+) -> set[DependencyMapping]:
+    venv_config = parse_venv_config(
+        (venv / "pyvenv.cfg").read_text()
+    )
+    mappings = gather_dependency_mappings(project_id, venv / "Lib" / "site-packages")
+    if venv_config.include_base_site_packages:
+        mappings.update(
+            gather_dependency_mappings(
+                project_id, venv_config.base_installation_path / "Lib" / "site-packages"
+            )
+        )
+    return mappings
+
+
+def _get_venv() -> Path:
+    return Path(sys.prefix)
+
+
+def _get_root_installation() -> Path:
+    return Path(sys.base_prefix)
+
+
+def _uses_venv() -> bool:
+    return _get_venv() != _get_root_installation()
+
+
+def get_mappings(project_id: str) -> set[DependencyMapping]:
+    if _uses_venv():
+        return gather_venv_mappings(project_id, _get_venv())
+    return gather_dependency_mappings(project_id, _get_root_installation())

--- a/src/tests/mapping/Lib/site-packages/mapped_package-1.0.0.dist-info/RECORD
+++ b/src/tests/mapping/Lib/site-packages/mapped_package-1.0.0.dist-info/RECORD
@@ -1,0 +1,10 @@
+_mapped_import_file.py,sha256=2jinvvJ_mJtFWwq2c5r0kLKA2QhQDJT_lb85CBc0UcU,22589
+mapped_import/__init__.py,sha256=98abxVfn8od1jJaTIr65YrYrIb7zMKbOJ5o68ryE2O0,2094
+mapped_import/main.py,sha256=X8eIpGlmHfnp7zazp5mdav228Itcf2lkiMP0tLU6X9c,140
+mapped_package-11.1.0.dist-info/LICENSE,sha256=Y6m7FH97jUPSEfBgAP5AYGc5rZP71csfhEvHQPi8Uew,56662
+mapped_package-11.1.0.dist-info/METADATA,sha256=sYK2WLlgLj7uN9DKsiS93-M9CuOHSiogmkVnvgc56Aw,9313
+mapped_package-11.1.0.dist-info/WHEEL,sha256=pWXrJbnZSH-J-PhYmKs2XNn4DHCPNBYq965vsBJBFvA,101
+mapped_package-11.1.0.dist-info/top_level.txt,sha256=riZqrk-hyZqh5f1Z0Zwii3dKfxEsByhu9cU9IODF-NY,4
+mapped_package-11.1.0.dist-info/zip-safe,sha256=frcCV1k9oG9oKj3dpUqdJg1PxRT2RSN_XKdLCPjaYaY,2
+mapped_package-11.1.0.dist-info/INSTALLER,sha256=HLHRd3rVxZqLVn0Nby492_jJUNACT5LifwfFYrwaW0E,12
+mapped_package-11.1.0.dist-info/RECORD,,

--- a/src/tests/mapping/Lib/site-packages/my_package_in_development-2.1.0.dist-info/RECORD
+++ b/src/tests/mapping/Lib/site-packages/my_package_in_development-2.1.0.dist-info/RECORD
@@ -1,0 +1,1 @@
+This is unparsable as this file MUST be skipped

--- a/src/tests/mapping/Lib/site-packages/some_package-1.0.0.dist-info/RECORD
+++ b/src/tests/mapping/Lib/site-packages/some_package-1.0.0.dist-info/RECORD
@@ -1,0 +1,8 @@
+some_package-0.4.6.dist-info/INSTALLER,sha256=5hhM4Q4mYTT9z6QB6PGpUAW81PGNFrYrdXMj4oM_6ak,2
+some_package-0.4.6.dist-info/METADATA,sha256=e67SnrUMOym9sz_4TjF3vxvAV4T3aF7NyqRHHH3YEMw,17158
+some_package-0.4.6.dist-info/RECORD,,
+some_package-0.4.6.dist-info/REQUESTED,sha256=47DEQpj8HBSa-_TImW-5JCeuQeRkm5NMpJWZG3hSuFU,0
+some_package-0.4.6.dist-info/WHEEL,sha256=cdcF4Fbd0FPtw2EMIOwH-3rSOTUdTCeOSXRMD1iLUb8,105
+some_package-0.4.6.dist-info/licenses/LICENSE.txt,sha256=ysNcAmhuXQSlpxQL-zs25zrtSWZW6JEQLkKIhteTAxg,1491
+some_package/__init__.py,sha256=wePQA4U20tKgYARySLEC047ucNX-g8pRLpYBuiHlLb8,266
+some_package/main.py,sha256=Top4EeEuaQdBWdteKMEcGOTeKeF19Q-Wo_6_Cj5kOzQ,2522

--- a/src/tests/mapping/pyvenv.cfg
+++ b/src/tests/mapping/pyvenv.cfg
@@ -1,0 +1,5 @@
+some = data
+home = c:\path\to\python
+more = data
+include-system-site-packages = false
+further = data

--- a/src/tests/test_mapping.py
+++ b/src/tests/test_mapping.py
@@ -1,13 +1,12 @@
 from pathlib import Path
 
 from check_dependencies.mapping import (
+    DependencyMapping,
     create_mapping,
-    find_smallest_valid_index,
     gather_venv_mappings,
     get_package_name_from_directory,
     parse_venv_config,
 )
-from check_dependencies.mapping import DependencyMapping
 
 
 def test_parse_example_config() -> None:
@@ -26,12 +25,13 @@ def test_create_mapping() -> None:
     mapping = create_mapping(
         "mapped_package",
         """
+../../Scripts/some.exe,sha256=vv43hgw89hcoanuv4jkgnnawuiogbek4j,7435
 _mapped_import_file.py,sha256=2jinvvJ_mJtFWwq2c5r0kLKA2QhQDJT_lb85CBc0UcU,22589
 mapped_import/__init__.py,sha256=98abxVfn8od1jJaTIr65YrYrIb7zMKbOJ5o68ryE2O0,2094
-mapped_import/main.py,sha256=X8eIpGlmHfnp7zazp5mdav228Itcf2lkiMP0tLU6X9c,140
+mapped_import\\main.py,sha256=X8eIpGlmHfnp7zazp5mdav228Itcf2lkiMP0tLU6X9c,140
 mapped_package-11.1.0.dist-info/LICENSE,sha256=Y6m7FH97jUPSEfBgAP5AYGc5rZP71csfhEvHQPi8Uew,56662
 mapped_package-11.1.0.dist-info/METADATA,sha256=sYK2WLlgLj7uN9DKsiS93-M9CuOHSiogmkVnvgc56Aw,9313
-mapped_package-11.1.0.dist-info/WHEEL,sha256=pWXrJbnZSH-J-PhYmKs2XNn4DHCPNBYq965vsBJBFvA,101
+mapped_package-11.1.0.dist-info\\WHEEL,sha256=pWXrJbnZSH-J-PhYmKs2XNn4DHCPNBYq965vsBJBFvA,101
 mapped_package-11.1.0.dist-info/top_level.txt,sha256=riZqrk-hyZqh5f1Z0Zwii3dKfxEsByhu9cU9IODF-NY,4
 mapped_package-11.1.0.dist-info/zip-safe,sha256=frcCV1k9oG9oKj3dpUqdJg1PxRT2RSN_XKdLCPjaYaY,2
 mapped_package-11.1.0.dist-info/INSTALLER,sha256=HLHRd3rVxZqLVn0Nby492_jJUNACT5LifwfFYrwaW0E,12
@@ -40,11 +40,6 @@ mapped_package-11.1.0.dist-info/RECORD,,
     )
     assert mapping.pip_name == "mapped_package"
     assert mapping.import_names == ("_mapped_import_file", "mapped_import")
-
-
-def test_smallest_valid_index() -> None:
-    assert find_smallest_valid_index([-1, 2]) == 2
-    assert find_smallest_valid_index([3, 4]) == 3
 
 
 def test_package_name_extraction() -> None:

--- a/src/tests/test_mapping.py
+++ b/src/tests/test_mapping.py
@@ -1,0 +1,64 @@
+from pathlib import Path
+
+from check_dependencies.mapping import (
+    create_mapping,
+    find_smallest_valid_index,
+    gather_venv_mappings,
+    get_package_name_from_directory,
+    parse_venv_config,
+)
+from check_dependencies.mapping import DependencyMapping
+
+
+def test_parse_example_config() -> None:
+    config = parse_venv_config("""
+some = data
+home = c:\\path\\to\\python
+more = data
+include-system-site-packages = false
+further = data
+""")
+    assert config.base_installation_path == Path("c:\\path\\to\\python")
+    assert not config.include_base_site_packages
+
+
+def test_create_mapping() -> None:
+    mapping = create_mapping(
+        "mapped_package",
+        """
+_mapped_import_file.py,sha256=2jinvvJ_mJtFWwq2c5r0kLKA2QhQDJT_lb85CBc0UcU,22589
+mapped_import/__init__.py,sha256=98abxVfn8od1jJaTIr65YrYrIb7zMKbOJ5o68ryE2O0,2094
+mapped_import/main.py,sha256=X8eIpGlmHfnp7zazp5mdav228Itcf2lkiMP0tLU6X9c,140
+mapped_package-11.1.0.dist-info/LICENSE,sha256=Y6m7FH97jUPSEfBgAP5AYGc5rZP71csfhEvHQPi8Uew,56662
+mapped_package-11.1.0.dist-info/METADATA,sha256=sYK2WLlgLj7uN9DKsiS93-M9CuOHSiogmkVnvgc56Aw,9313
+mapped_package-11.1.0.dist-info/WHEEL,sha256=pWXrJbnZSH-J-PhYmKs2XNn4DHCPNBYq965vsBJBFvA,101
+mapped_package-11.1.0.dist-info/top_level.txt,sha256=riZqrk-hyZqh5f1Z0Zwii3dKfxEsByhu9cU9IODF-NY,4
+mapped_package-11.1.0.dist-info/zip-safe,sha256=frcCV1k9oG9oKj3dpUqdJg1PxRT2RSN_XKdLCPjaYaY,2
+mapped_package-11.1.0.dist-info/INSTALLER,sha256=HLHRd3rVxZqLVn0Nby492_jJUNACT5LifwfFYrwaW0E,12
+mapped_package-11.1.0.dist-info/RECORD,,
+""",
+    )
+    assert mapping.pip_name == "mapped_package"
+    assert mapping.import_names == ("_mapped_import_file", "mapped_import")
+
+
+def test_smallest_valid_index() -> None:
+    assert find_smallest_valid_index([-1, 2]) == 2
+    assert find_smallest_valid_index([3, 4]) == 3
+
+
+def test_package_name_extraction() -> None:
+    assert (
+        get_package_name_from_directory("mapped_package-11.1.0.dist-info")
+        == "mapped_package"
+    )
+
+
+def test_integration() -> None:
+    mappings = gather_venv_mappings(
+        "my_package_in_development", Path(__file__).parent / "mapping"
+    )
+    assert mappings == {
+        DependencyMapping("some_package", ("some_package",)),
+        DependencyMapping("mapped_package", ("_mapped_import_file", "mapped_import")),
+    }


### PR DESCRIPTION
Hi, great project you got there! I was looking for something just like it

Unfortunately, I'm too lazy to maintain `[tool.check-dependencies.provides]` manually. The list can quickly get long with typing packages and such. So I set on to build a little crawler to gather those mappings automagically...

Every package leaves a `<package_name>-<version>.dist-info` directory on install in `<path_to_python>/Libs/site-packages`. All installed files are tracked in a file called `RECORD` to enable a clean uninstall. This means that the `RECORD` file tracks any and all mappings since Python uses paths and filenames for imports.

This prototype parses those `RECORD` files. Further, it is intelligent about the venv and potentially disabled global parent or a plain uncivilized global installation.

I didn't test all setup options or cross platform scenarios yet, but I'm reasonably confident it'll work. A quick test on this project with a venv on Windoof reveals:
```console
> uv run python -c "from check_dependencies import mapping; print(mapping.get_mappings('check_dependencies'))"

{DependencyMapping(pip_name='packaging', import_names=('packaging',)), DependencyMapping(pip_name='types_docutils', import_names=('docutils-stubs',)), DependencyMapping(pip_name='types_pexpect', import_names=('pexpect-stubs',)), DependencyMappi
ng(pip_name='ruff', import_names=('ruff',)), DependencyMapping(pip_name='pytest', import_names=('_pytest', 'py', 'pytest')), DependencyMapping(pip_name='ty', import_names=('ty',)), DependencyMapping(pip_name='pytest_cov', import_names=('pytest_
cov',)), DependencyMapping(pip_name='pluggy', import_names=('pluggy',)), DependencyMapping(pip_name='types_pygments', import_names=('pygments-stubs',)), DependencyMapping(pip_name='types_toml', import_names=('toml-stubs',)), DependencyMapping(p
ip_name='colorama', import_names=('colorama',)), DependencyMapping(pip_name='pygments', import_names=('pygments',)), DependencyMapping(pip_name='coverage', import_names=('a1_coverage', 'coverage')), DependencyMapping(pip_name='iniconfig', import_names=('iniconfig',))}
```
Obviously, I didn't filter/remove `package_name==import_name` yet. But that is an easy fix!

Is this something you are interested in? If so, how would you like to adapt the provides section as it only allows a mapping from package name to a single import, but there can be multiple.?

Cheers,
SinTh0r4s

PS: Your `make` setup is not platform independent. Dare I recommend you take a look at `poethepoet` to enable contributions from all platforms?
