### PR TITLE
Auto detect mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `check-dependencies--verbose` also shows all extras, missing, provides and configurations as comments.
+- `check-dependencies --verbose` also shows all extras, missing, provides and configurations as comments.
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ config file. This can be used to generate the initial config file or to update i
 ## check-dependencies
 
 ```text
-usage: check-dependencies [-h] [--include-dev] [--verbose] [--all] [--missing MISSING] [--extra EXTRA] [--provides PACKAGE=IMPORT] [--include INCLUDE] file_name [file_name ...]
+usage: check-dependencies [-h] [--include-dev] [--verbose] [--all] [--missing MODULE] [--extra PACKAGE]
+                          [--provides PACKAGE=IMPORT] [--include INCLUDE] [--provides-from-venv PYTHON_ENV]
+                          file_name [file_name ...]
 
 Find undeclared and unused (or all) imports in Python files
 
@@ -29,20 +31,24 @@ options:
   --include-dev         Include dev dependencies
   --verbose             Show every import of a package
   --all                 Show all imports (including correct ones)
-  --missing MISSING     Comma separated list of requirements known to be missing.
-                        Assume they are part of the requirements.
-  --extra EXTRA         Comma separated list of requirements known to not be imported.
-                        Assume they are not part of the requirements.
-                        This can be plugins or similar that affect the package but are not imported explicitly.
+  --missing MODULE      Comma separated list of requirements known to be missing. Assume they are part of the
+                        requirements. Can be specified multiple times.Toml Key: [tool.check-
+                        dependencies] mising=[]
+  --extra PACKAGE       Comma separated list of requirements known to not be imported. Assume they are not part
+                        of the requirements. This can be plugins or similar that affect the package but are not
+                        imported explicitly. Can be specified multiple times. Toml Key: [tool.check-
+                        dependencies] known_extra=[]
   --provides PACKAGE=IMPORT
-                        Map a package name to its import name for packages whose import name differs
-                        from the package name. Can be specified multiple times.
-                        E.g. --provides Pillow=PIL --provides PyJWT=jwt. The package name is
-                        normalized (case-insensitive, hyphens and underscores are equivalent),
-                        so Pillow=PIL, pillow=PIL and PIL-ow=PIL are all the same.
+                        Map a package name to its import name for packages whose import name differs from the
+                        package name. Can be specified multiple times. E.g. --provides Pillow=PIL --provides
+                        PyJWT=jwt. The package name is normalized (case-insensitive, hyphens and underscores are
+                        equivalent), so Pillow=PIL, pillow=PIL and PIL-ow=PIL are all the same.Toml Key:
+                        [tool.check-dependencies.provides]
   --include, -I INCLUDE
-                        Additional config files to include. Can be specified multiple times.
-                        E.g. --include check-dependencies.toml.
+                        Additional config files to include. Can be specified multiple times. E.g. --include
+                        check-dependencies.toml.Toml Key: [tool.check-dependencies] include=[]
+  --provides-from-venv PYTHON_ENV
+                        Path to a virtual environment to include all packages installed in it as provides.
 ```
 
 ### Output
@@ -100,6 +106,80 @@ check-dependencies  project/src/
 + requests
 ```
 
+#### Add known extra requirements
+Add requirements that are known to be used, but not imported in the codebase (e.g. plugins).
+
+Via CLI:
+```text
+check-dependencies --extra snowflake-sqlalchemy project/src
+```
+
+Via `pyproject.toml`:
+```toml
+[tool.check-dependencies]
+known-extra = [ "snowflake-sqlalchemy" ]
+```
+
+#### Translate package names
+Some packages have different names for the package and the import (e.g. Pillow is imported as PIL).
+
+Via CLI:
+```text
+check-dependencies --provides Pillow=PIL --provides PyJWT=jwt project/src
+```
+
+Via `pyproject.toml`:
+```toml
+[tool.check-dependencies.provides]
+Pillow = "PIL"
+PyJWT = "jwt"
+```
+
+#### Add known missing requirements
+Add requirements that are known to be missing, but are imported in the codebase.
+
+Via CLI:
+```text
+check-dependencies --missing numpy check-dependencies project/src
+```
+
+Via `pyproject.toml`:
+```toml
+[tool.check-dependencies]
+known-missing = [ "numpy" ]
+```
+
+
+#### Include additional config file
+Use an additional config file to include extra or missing dependencies or provides.
+This is useful for monorepos or similar setups where multiple packages share a common configuration file.
+
+Via CLI:
+```text
+> check-dependencies project/src/
+! snowflake-sqlalchemy
+> check-dependencies --include ../global-check-dependencies.toml project/src/
+```
+
+Via `pyproject.toml`:
+```toml
+[tool.check-dependencies]
+includes = [ "../global-check-dependencies.toml" ]
+```
+
+#### Include dev dependencies
+
+```shell
+textcheck-dependencies --include-dev project/tests/
+```
+
+#### Include provides from virtual environment
+
+Get all provides from the virtual environment and include them in the check.
+```text
+check-dependencies --provides-from-venv .venv/bin/python project/src/
+```
+
 #### Output all dependencies
 
 Output all dependencies, including the correct ones.
@@ -118,6 +198,14 @@ Output each erroneous import and extra dependency with cause, file name and line
 
 ```text
 check-dependencies --verbose project/src/
+# ALL=False
+# INCLUDE_DEV=False
+# EXTRA pytest
+# EXTRA toml
+# EXTRA tomllib
+# MISSING check_dependencies
+# MISSING toml
+# MISSING tomllib
 !NA matplotlib project/src/main.py:4
 +EXTRA project/pyproject.toml requests
 ```
@@ -126,8 +214,16 @@ check-dependencies --verbose project/src/
 
 Output all imports, including the correct ones with file name and line number.
 
-```commandline
+```text
 check-dependencies --verbose --all project/src/
+# ALL=True
+# INCLUDE_DEV=False
+# EXTRA pytest
+# EXTRA toml
+# EXTRA tomllib
+# MISSING check_dependencies
+# MISSING toml
+# MISSING tomllib
  OK project/src/data.py:5 pandas
  OK project/src/main.py:3 pandas
  OK project/src/plotting.py:4 pandas
@@ -141,23 +237,7 @@ check-dependencies --verbose --all project/src/
 
 ### Configuration
 
-The configuration is read from `pyproject.toml` file. The configuration file
-supports the following entries:
-
-- `[tool.check-dependencies.known-extra]` to
-  add extra packages to the list of dependencies.
-
-- `[tool.check-dependencies.known-missing]` does the opposite, it will
-  ignore existing dependencies even if they are not imported. This is useful for
-  packages, that provide functionality via plugins (e.g. sqlalchemy plugins)
-  and are not imported directly in the codebase.
-- `[tool.check-dependencies.provides]` to map package names to import names for
-  packages whose import name differs from the package name.
-  E.g. Pillow is imported as PIL, but the package name is Pillow.
-  The value can be either a single module or a list of modules.
-- `[tool.check-dependencies.includes]` to include additional config files.
-  This is useful for monorepos or similar setups where multiple packages share a
-  common configuration file.
+The configuration is read from `pyproject.toml` file.
 
 ```toml
 [tool.check-dependencies]
@@ -184,15 +264,15 @@ includes = [
 
 #### Exit code
 
-- 0: No missing or superfluous dependencies found
-- 2: Missing (used, but not declared in pyproject.toml) dependencies found
-- 4: Extra (declaredfcheck_ in pyproject.toml, but unused) dependencies found
-- 6: Both missing and superfluous dependencies found
-- 8: Could not find associated pyproject.toml file
-- 16: Could not parse source file(s)
-- 1: Another error occurred
+- `0`: No missing or superfluous dependencies found
+- `2`: Missing (used, but not declared in pyproject.toml) dependencies found
+- `4`: Extra (declaredfcheck_ in pyproject.toml, but unused) dependencies found
+- `6`: Both missing and superfluous dependencies found
+- `8`: Could not find associated pyproject.toml file
+- `16`: Could not parse source file(s)
+- `1`: Another error occurred
 
-## dependency-writer
+## Dependency Writer
 
 The `dependency-writer` CLI application can be used to write the mapping of imports to packages to the config file.
 It can be used to generate the initial config file or to update it after changes in the codebase.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ options:
   --all                 Show all imports (including correct ones)
   --missing MODULE      Comma separated list of requirements known to be missing. Assume they are part of the
                         requirements. Can be specified multiple times.Toml Key: [tool.check-
-                        dependencies] mising=[]
+                        dependencies] known_mising=[]
   --extra PACKAGE       Comma separated list of requirements known to not be imported. Assume they are not part
                         of the requirements. This can be plugins or similar that affect the package but are not
                         imported explicitly. Can be specified multiple times. Toml Key: [tool.check-
@@ -46,7 +46,7 @@ options:
                         [tool.check-dependencies.provides]
   --include, -I INCLUDE
                         Additional config files to include. Can be specified multiple times. E.g. --include
-                        check-dependencies.toml.Toml Key: [tool.check-dependencies] include=[]
+                        check-dependencies.toml.Toml Key: [tool.check-dependencies] includes=[]
   --provides-from-venv PYTHON_ENV
                         Path to a virtual environment to include all packages installed in it as provides.
 ```
@@ -170,7 +170,7 @@ includes = [ "../global-check-dependencies.toml" ]
 #### Include dev dependencies
 
 ```shell
-textcheck-dependencies --include-dev project/tests/
+check-dependencies --include-dev project/tests/
 ```
 
 #### Include provides from virtual environment
@@ -266,7 +266,7 @@ includes = [
 
 - `0`: No missing or superfluous dependencies found
 - `2`: Missing (used, but not declared in pyproject.toml) dependencies found
-- `4`: Extra (declaredfcheck_ in pyproject.toml, but unused) dependencies found
+- `4`: Extra (declared in pyproject.toml, but unused) dependencies found
 - `6`: Both missing and superfluous dependencies found
 - `8`: Could not find associated pyproject.toml file
 - `16`: Could not parse source file(s)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,9 +63,6 @@ known-extra = [
 ]
 includes = ["src/tests/check-dependencies.toml"]
 
-[tool.check-dependencies.provides]
-pytest = ["_pytest", "py"]
-
 [tool.ruff]
 exclude = ["src/tests/data"]
 

--- a/src/check_dependencies/__main__.py
+++ b/src/check_dependencies/__main__.py
@@ -56,37 +56,47 @@ def main() -> int:
         help="Show all imports (including correct ones)",
     )
     parser.add_argument(
+        "--provides-from-venv",
+        metavar="PYTHON_ENV",
+        type=Path,
+        help="Path to a virtual environment to include all packages installed in it"
+        " as provides.",
+    )
+    parser.add_argument(
         "--missing",
         type=str,
         action=_MultiSepAction,
-        metavar="MODULE",
+        metavar="MODULE,...",
         default=[],
         help="Comma separated list of requirements known to be missing."
         " Assume they are part of the requirements."
-        " Can be specified multiple times.",
+        " Can be specified multiple times."
+        " Toml Key: [tool.check-dependencies] mising=[]",
     )
     parser.add_argument(
         "--extra",
         type=str,
         action=_MultiSepAction,
-        metavar="PACKAGE",
+        metavar="PACKAGE,...",
         default=[],
         help="Comma separated list of requirements known to not be imported."
         " Assume they are not part of the requirements. This can be plugins or similar"
         " that affect the package but are not imported explicitly."
-        " Can be specified multiple times.",
+        " Can be specified multiple times."
+        " Toml Key: [tool.check-dependencies] known_extra=[]",
     )
     parser.add_argument(
         "--provides",
         type=str,
         action=_MultiSepAction,
         default=[],
-        metavar="PACKAGE=IMPORT",
-        help="Map a package name to its import name for packages whose import name"
-        " differs from the package name. Can be specified multiple times."
+        metavar="PACKAGE=MODULE,...",
+        help="Map a package name to its module (import) name for packages whose import"
+        " name differs from the package name. Can be specified multiple times."
         " E.g. --provides Pillow=PIL --provides PyJWT=jwt."
         " The package name is normalized (case-insensitive, hyphens and underscores"
-        " are equivalent), so Pillow=PIL, pillow=PIL and PIL-ow=PIL are all the same.",
+        " are equivalent), so Pillow=PIL, pillow=PIL and PIL-ow=PIL are all the same."
+        " Toml Key: [tool.check-dependencies.provides]",
     )
     parser.add_argument(
         "--include",
@@ -95,15 +105,10 @@ def main() -> int:
         action="append",
         default=[],
         help="Additional config files to include."
-        " Can be specified multiple times. E.g. --include check-dependencies.toml.",
+        " Can be specified multiple times. E.g. --include check-dependencies.toml."
+        " Toml Key: [tool.check-dependencies] include=[]",
     )
-    parser.add_argument(
-        "--provides-from-venv",
-        metavar="PYTHON_ENV",
-        type=Path,
-        help="Path to a virtual environment to include all packages installed in it"
-        " as provides.",
-    )
+
     args = parser.parse_args()
 
     cfg = AppConfig.from_cli_args(

--- a/src/check_dependencies/__main__.py
+++ b/src/check_dependencies/__main__.py
@@ -115,6 +115,7 @@ def main() -> int:
         verbose=args.verbose,
         show_all=args.all,
         includes=args.include,
+        provides_from_venv=args.provides_from_venv,
     )
     wrong_import_lines = yield_wrong_imports(args.file_name, cfg)
     try:

--- a/src/check_dependencies/__main__.py
+++ b/src/check_dependencies/__main__.py
@@ -71,7 +71,7 @@ def main() -> int:
         help="Comma separated list of requirements known to be missing."
         " Assume they are part of the requirements."
         " Can be specified multiple times."
-        " Toml Key: [tool.check-dependencies] mising=[]",
+        " Toml Key: [tool.check-dependencies] known-missing=[]",
     )
     parser.add_argument(
         "--extra",
@@ -83,7 +83,7 @@ def main() -> int:
         " Assume they are not part of the requirements. This can be plugins or similar"
         " that affect the package but are not imported explicitly."
         " Can be specified multiple times."
-        " Toml Key: [tool.check-dependencies] known_extra=[]",
+        " Toml Key: [tool.check-dependencies] known-extra=[]",
     )
     parser.add_argument(
         "--provides",
@@ -106,7 +106,7 @@ def main() -> int:
         default=[],
         help="Additional config files to include."
         " Can be specified multiple times. E.g. --include check-dependencies.toml."
-        " Toml Key: [tool.check-dependencies] include=[]",
+        " Toml Key: [tool.check-dependencies] includes=[]",
     )
 
     args = parser.parse_args()

--- a/src/check_dependencies/__main__.py
+++ b/src/check_dependencies/__main__.py
@@ -57,10 +57,10 @@ def main() -> int:
     )
     parser.add_argument(
         "--provides-from-venv",
-        metavar="PYTHON_ENV",
+        metavar="PYTHON_EXECUTABLE",
         type=Path,
-        help="Path to a virtual environment to include all packages installed in it"
-        " as provides.",
+        help="Path to the virtual environment's Python executable (for example,"
+        " .venv/bin/python) to include all packages installed in it as provides.",
     )
     parser.add_argument(
         "--missing",

--- a/src/check_dependencies/app_config.py
+++ b/src/check_dependencies/app_config.py
@@ -16,6 +16,7 @@ from typing import (
 )
 
 from check_dependencies.lib import Dependency, Module, Package, Packages
+from check_dependencies.provides import mappings_for_env
 from check_dependencies.pyproject_toml import ConfigToml, PyProjectToml
 
 if TYPE_CHECKING:
@@ -50,6 +51,7 @@ class AppConfig:
         verbose: bool = False,
         show_all: bool = False,
         includes: Sequence[Path] = (),
+        provides_from_venv: Path | None = None,
     ) -> AppConfig:
         """Create an AppConfig instance from CLI arguments.
 
@@ -66,7 +68,11 @@ class AppConfig:
         for package_name, _, module in (map1.partition("=") for map1 in provides):
             if package_name.strip() and module.strip():
                 provides_list.append((Package(package_name), Module(module)))
-
+        if provides_from_venv:
+            provides_list.extend(
+                (Package(package_name), Module(module_name))
+                for (package_name, module_name) in mappings_for_env(provides_from_venv)
+            )
         src_cfg = PyProjectToml.for_paths(
             file_names or [Path()], include_dev=include_dev
         )

--- a/src/check_dependencies/app_config.py
+++ b/src/check_dependencies/app_config.py
@@ -55,14 +55,17 @@ class AppConfig:
     ) -> AppConfig:
         """Create an AppConfig instance from CLI arguments.
 
-        :file_names: List of file paths to analyze.
-        :known_extra: List of known extra dependencies.
-        :known_missing: List of known missing dependencies.
-        :provides: Iterable of strings in the format "package=module" to specify
+        :param file_names: List of file paths to analyze.
+        :param known_extra: List of known extra dependencies.
+        :param known_missing: List of known missing dependencies.
+        :param provides: Iterable of strings in the format "package=module" to specify
             provided modules.
-        :include_dev: Whether to include development dependencies from pyproject.toml.
-        :verbose: Whether to include detailed information in the output.
-        :show_all: Whether to show all dependencies, including those that are OK.
+        :param include_dev: Whether to include development dependencies from
+            pyproject.toml.
+        :param verbose: Whether to include detailed information in the output.
+        :param show_all: Whether to show all dependencies, including those that are OK.
+        :param includes: Files containing additional configs to include.
+        :param provides_from_venv: Path to a python executable of a virtual environment.
         """
         provides_list: list[tuple[Package, Module]] = []
         for package_name, _, module in (map1.partition("=") for map1 in provides):

--- a/src/check_dependencies/provides.py
+++ b/src/check_dependencies/provides.py
@@ -8,9 +8,14 @@ from pathlib import Path
 from typing import Iterable
 
 
-def mappings_for_env(python: Path) -> dict[str, list[str]]:
-    """Get the mappings."""
-    package_mappings = sorted(
+def mappings_for_env(python: Path) -> list[tuple[str, str]]:
+    """Get the mappings.
+
+    :arg python: Path to python executable belonging to the virtual
+        environment, e.g. $VIRTUAL_ENV/bin/python.
+    :return: a list of mappings of package name to module name.
+    """
+    return sorted(
         (package_name, import_name)
         for path in _get_paths(python)
         for record_file in path.glob("*.dist-info/")
@@ -18,6 +23,18 @@ def mappings_for_env(python: Path) -> dict[str, list[str]]:
         for package_name, import_name in _mapping_from_record(record_file)
     )
 
+
+def collect_mappings(
+    package_mappings: Iterable[tuple[str, str]],
+) -> dict[str, list[str]]:
+    """Collect package provides modules mappings directly from an installed environment.
+
+    :param package_mappings: package mappings to collect, as an iterable
+        of (package_name, import_name) tuples.
+        The packages must be sorted.
+
+    :return a mapping of packages to lists of module names.
+    """
     return {
         key: sorted({value for _, value in values})
         for key, values in groupby(package_mappings, lambda x: x[0])

--- a/src/check_dependencies/writer.py
+++ b/src/check_dependencies/writer.py
@@ -7,7 +7,7 @@ import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from check_dependencies.provides import mappings_for_env
+from check_dependencies.provides import collect_mappings, mappings_for_env
 
 EXIT_SUCCESS, EXIT_VALUE_ERROR, EXIT_FAILURE = 0, 1, 2
 try:
@@ -50,7 +50,7 @@ def _get_arg_parser() -> argparse.ArgumentParser:
 
 
 def _update_config(config_file: Path, python: Path) -> None:
-    provides = mappings_for_env(python)
+    provides = collect_mappings(mappings_for_env(python))
     is_stdout = config_file.as_posix() == "-"
 
     cfg = _get_existing_config(config_file, is_stdout=is_stdout)

--- a/src/tests/test_main.py
+++ b/src/tests/test_main.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import ast
+import sys
 import time
 from pathlib import Path
 from textwrap import dedent
@@ -436,6 +437,17 @@ class TestYieldWrongImports:
         )
         res = self.fn(file_names=[SRC], args=["--include", extra_cfg.as_posix()])
         assert res == []
+
+    def test_provides_from_venv(self) -> None:
+        """Test that provides from the venv are included."""
+        res = self.fn(
+            overwrite_cfg=POETRY,
+            file_names=[SRC],
+            args=["--provides-from-venv", sys.executable, "--verbose"],
+            with_comment=True,
+        )
+        res = [line for line in res if line.startswith("# PROVIDES")]
+        assert "# PROVIDES pytest -> [_pytest, py]" in res
 
 
 @pytest.mark.parametrize(

--- a/src/tests/test_provides.py
+++ b/src/tests/test_provides.py
@@ -19,7 +19,7 @@ def test_mappings_for_env() -> None:
 
 
 def test_collect_mappings__mocked_python(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Test mappings_for_env with mocked python."""
+    """Test collect_mappings(mappings_for_env(...)) with mocked python."""
     monkeypatch.setattr(
         provides, "_get_paths", lambda _: [DATA / "mapping" / "site-packages"]
     )
@@ -45,7 +45,7 @@ def test_mappings_for_env__mocked_python(monkeypatch: pytest.MonkeyPatch) -> Non
 
 
 def test_collect_mappings() -> None:
-    """Test mappings_for_env with mocked python."""
+    """Test collect_mappings with mocked python."""
     mappings = provides.collect_mappings([("a", "x"), ("a", "y"), ("b", "z")])
     assert mappings == {
         "a": ["x", "y"],

--- a/src/tests/test_provides.py
+++ b/src/tests/test_provides.py
@@ -18,17 +18,39 @@ def test_mappings_for_env() -> None:
     assert res
 
 
+def test_collect_mappings__mocked_python(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test mappings_for_env with mocked python."""
+    monkeypatch.setattr(
+        provides, "_get_paths", lambda _: [DATA / "mapping" / "site-packages"]
+    )
+    mappings = provides.collect_mappings(provides.mappings_for_env(Path("some-python")))
+    assert mappings == {
+        "mapped_package": ["_mapped_import_file", "mapped_import"],
+        "pillow": ["PIL"],
+    }
+
+
 def test_mappings_for_env__mocked_python(monkeypatch: pytest.MonkeyPatch) -> None:
     """Test mappings_for_env with mocked python."""
     monkeypatch.setattr(
         provides, "_get_paths", lambda _: [DATA / "mapping" / "site-packages"]
     )
     mappings = provides.mappings_for_env(Path("some-python"))
+    assert mappings == [
+        ("mapped_package", "_mapped_import_file"),
+        ("mapped_package", "mapped_import"),
+        ("pillow", "PIL"),
+    ]
+    assert mappings == sorted(mappings)
+
+
+def test_collect_mappings() -> None:
+    """Test mappings_for_env with mocked python."""
+    mappings = provides.collect_mappings([("a", "x"), ("a", "y"), ("b", "z")])
     assert mappings == {
-        "mapped_package": ["_mapped_import_file", "mapped_import"],
-        "pillow": ["PIL"],
+        "a": ["x", "y"],
+        "b": ["z"],
     }
-    assert sorted(mappings.keys()) == list(mappings.keys())
 
 
 def test__get_paths() -> None:


### PR DESCRIPTION
This pull request adds enhanced support for handling package-to-import mappings, especially from virtual environments, and improves the CLI and documentation for the `check-dependencies` tool. The most important changes are the introduction of the `--provides-from-venv` CLI option, clearer and more detailed CLI help and documentation. Several tests have also been added or updated to cover these new features.

**CLI and Documentation Improvements**
* Added the `--provides-from-venv` CLI option, allowing users to include all packages installed in a given virtual environment as provides mappings. This is reflected in both the CLI parser (`src/check_dependencies/__main__.py`) and the documentation (`README.md`). [[1]](diffhunk://#diff-ad19cb6ba0ef334c64c29ed4b1a8ad98b6606e0990cde31ca2ed306b2054d8b7R58-R99) [[2]](diffhunk://#diff-ad19cb6ba0ef334c64c29ed4b1a8ad98b6606e0990cde31ca2ed306b2054d8b7R123) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L20-R22) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L32-R51) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R109-R182)
* Improved CLI help messages for options such as `--missing`, `--extra`, `--provides`, and `--include`, clarifying their usage and corresponding TOML keys. [[1]](diffhunk://#diff-ad19cb6ba0ef334c64c29ed4b1a8ad98b6606e0990cde31ca2ed306b2054d8b7R58-R99) [[2]](diffhunk://#diff-ad19cb6ba0ef334c64c29ed4b1a8ad98b6606e0990cde31ca2ed306b2054d8b7L98-R111)
* Expanded the `README.md` with detailed sections and examples for all major features, including the new virtual environment support, configuration options, and expected output. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R109-R182) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R201-R208) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L129-R226) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L144-R240) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L187-R275)

**Provides Mapping Logic**
* Refactored `mappings_for_env` in `src/check_dependencies/provides.py` to return a sorted list of `(package_name, module_name)` tuples, and added a new `collect_mappings` function to aggregate these into a dictionary.
* Updated the application configuration (`AppConfig`) to support merging provides mappings from both CLI arguments and the virtual environment. [[1]](diffhunk://#diff-39024f8a4acf4aa15ff815b88f209b4f9a580958e918ca99be1360cecf828948R19) [[2]](diffhunk://#diff-39024f8a4acf4aa15ff815b88f209b4f9a580958e918ca99be1360cecf828948R54) [[3]](diffhunk://#diff-39024f8a4acf4aa15ff815b88f209b4f9a580958e918ca99be1360cecf828948L69-R75)
* Updated the dependency writer logic to use the new `collect_mappings` function for updating configuration files with provides mappings from a virtual environment. [[1]](diffhunk://#diff-509e9261653dbe683b355a502bca03e21be71fea2228fed9d1dab16a18b5bad9L10-R10) [[2]](diffhunk://#diff-509e9261653dbe683b355a502bca03e21be71fea2228fed9d1dab16a18b5bad9L53-R53)

**Testing**
* Added and updated tests to cover the new `--provides-from-venv` functionality and the refactored provides mapping logic, ensuring correct behavior and output. [[1]](diffhunk://#diff-24e5bb3549f1f9cf8747aa45c2019439c770d4acd7e36ee319efa978b3c859cbR441-R451) [[2]](diffhunk://#diff-72c747d072ba15d858353b8c9c427b7f9b7509227175fc50115b4d8a20166f5fL21-R53)

**Configuration File Cleanup**
* Removed an obsolete `[tool.check-dependencies.provides]` section from `pyproject.toml`.