### PR TITLE
Add version flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Upcoming
 
+### Added
+
+- `check-dependencies --version` to show the installed package version.
+
 ### Changed
 
 ## [1.3. 0] -- 2026-04-06 - Gets provides from virtual environment

--- a/README.md
+++ b/README.md
@@ -17,9 +17,10 @@ config file. This can be used to generate the initial config file or to update i
 ## check-dependencies
 
 ```text
-usage: check-dependencies [-h] [--include-dev] [--verbose] [--all] [--missing MODULE] [--extra PACKAGE]
-                          [--provides PACKAGE=IMPORT] [--include INCLUDE] [--provides-from-venv PYTHON_ENV]
-                          file_name [file_name ...]
+usage: check-dependencies [-h] [--version] [--include-dev] [--verbose] [--all]
+                          [--provides-from-venv PYTHON_EXECUTABLE] [--missing MODULE,...]
+                          [--extra PACKAGE,...] [--provides PACKAGE=MODULE,...]
+                          [--include INCLUDE] file_name [file_name ...]
 
 Find undeclared and unused (or all) imports in Python files
 
@@ -28,28 +29,29 @@ positional arguments:
 
 options:
   -h, --help            show this help message and exit
+  --version             show program's version number and exit
   --include-dev         Include dev dependencies
   --verbose             Show every import of a package
   --all                 Show all imports (including correct ones)
-  --missing MODULE      Comma separated list of requirements known to be missing. Assume they are part of the
-                        requirements. Can be specified multiple times.Toml Key: [tool.check-
-                        dependencies] known_mising=[]
-  --extra PACKAGE       Comma separated list of requirements known to not be imported. Assume they are not part
+  --provides-from-venv PYTHON_EXECUTABLE
+                        Path to the virtual environment's Python executable (for example, .venv/bin/python)
+                        to include all packages installed in it as provides.
+  --missing MODULE,...  Comma separated list of requirements known to be missing. Assume they are part of the
+                        requirements. Can be specified multiple times. Toml Key: [tool.check-
+                        dependencies] known-missing=[]
+  --extra PACKAGE,...   Comma separated list of requirements known to not be imported. Assume they are not part
                         of the requirements. This can be plugins or similar that affect the package but are not
                         imported explicitly. Can be specified multiple times. Toml Key: [tool.check-
-                        dependencies] known_extra=[]
-  --provides PACKAGE=IMPORT
+                        dependencies] known-extra=[]
+  --provides PACKAGE=MODULE,...
                         Map a package name to its import name for packages whose import name differs from the
                         package name. Can be specified multiple times. E.g. --provides Pillow=PIL --provides
-                        PyJWT=jwt. The package name is normalized (case-insensitive, hyphens and underscores are
-                        equivalent), so Pillow=PIL, pillow=PIL and PIL-ow=PIL are all the same.Toml Key:
+                        PyJWT=jwt. The package name is normalized (case-insensitive, hyphens and underscores
+                        are equivalent), so Pillow=PIL, pillow=PIL and PIL-ow=PIL are all the same. Toml Key:
                         [tool.check-dependencies.provides]
   --include, -I INCLUDE
                         Additional config files to include. Can be specified multiple times. E.g. --include
                         check-dependencies.toml.Toml Key: [tool.check-dependencies] includes=[]
-  --provides-from-venv PYTHON_ENV
-                        Path to a virtual environment python executable to include all packages installed in it
-                        as provides.
 ```
 
 ### Output

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ includes = ["src/tests/check-dependencies.toml"]
 [tool.poe.tasks]
 typing = "ty check src/"
 pytest = "pytest src/tests"
-lint = [{cmd="ruff check --fix src/"}, {cmd="ruff format src/"}]
+lint = [{cmd="ruff format src/"}, {cmd="ruff check --fix src/"}]
 check = ["lint", "typing", "pytest"]
 
 [tool.ruff]

--- a/src/check_dependencies/__main__.py
+++ b/src/check_dependencies/__main__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import logging
 import sys
+from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -13,6 +14,17 @@ from check_dependencies.main import yield_wrong_imports
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
+
+
+_DIST_NAME = "check-dependencies"
+
+
+def _get_version() -> str:
+    """Return the installed package version."""
+    try:
+        return version(_DIST_NAME)
+    except PackageNotFoundError:
+        return "unknown"
 
 
 def main() -> int:
@@ -29,6 +41,11 @@ def main() -> int:
     parser = argparse.ArgumentParser(
         description="Find undeclared and unused (or all) imports in Python files",
         add_help=True,
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"%(prog)s {_get_version()}",
     )
 
     parser.add_argument(

--- a/src/check_dependencies/app_config.py
+++ b/src/check_dependencies/app_config.py
@@ -67,15 +67,6 @@ class AppConfig:
         :param includes: Files containing additional configs to include.
         :param provides_from_venv: Path to a python executable of a virtual environment.
         """
-        provides_list: list[tuple[Package, Module]] = []
-        for package_name, _, module in (map1.partition("=") for map1 in provides):
-            if package_name.strip() and module.strip():
-                provides_list.append((Package(package_name), Module(module)))
-        if provides_from_venv:
-            provides_list.extend(
-                (Package(package_name), Module(module_name))
-                for (package_name, module_name) in mappings_for_env(provides_from_venv)
-            )
         src_cfg = PyProjectToml.for_paths(
             file_names or [Path()], include_dev=include_dev
         )
@@ -117,7 +108,9 @@ class AppConfig:
                 for module in (*known_missing, *cfg_of("known_missing"))
                 if module.strip()
             ),
-            provides=Packages([*provides_list, *cfg_of("provides")]),
+            provides=Packages(
+                [*_get_provides(provides, provides_from_venv), *cfg_of("provides")]
+            ),
             dependencies=src_cfg.dependencies,
             pyproject_file=src_cfg.path,
         )
@@ -167,3 +160,16 @@ class AppConfig:
         """
         name = Dependency.EXTRA.name if self.verbose else ""
         yield f"{Dependency.EXTRA.value}{name} {module}"
+
+
+def _get_provides(
+    provides: Iterable[str], provides_from_venv: Path | None
+) -> Iterable[tuple[Package, Module]]:
+    """Parse the provides argument and collect provides from a virtual environment."""
+    for package_name, _, module in (map1.partition("=") for map1 in provides):
+        if package_name.strip() and module.strip():
+            yield Package(package_name), Module(module)
+
+    if provides_from_venv:
+        for package_name, module_name in mappings_for_env(provides_from_venv):
+            yield Package(package_name), Module(module_name)

--- a/src/tests/test_main.py
+++ b/src/tests/test_main.py
@@ -102,7 +102,7 @@ def test_get_version_without_package_metadata(monkeypatch: pytest.MonkeyPatch) -
     """Return `unknown` when package metadata is unavailable."""
 
     def _raise_package_not_found(_dist_name: str) -> str:
-        raise PackageNotFoundError
+        raise PackageNotFoundError(_dist_name)
 
     monkeypatch.setattr("check_dependencies.__main__.version", _raise_package_not_found)
 

--- a/src/tests/test_main.py
+++ b/src/tests/test_main.py
@@ -6,6 +6,7 @@ import argparse
 import ast
 import sys
 import time
+from importlib.metadata import PackageNotFoundError
 from pathlib import Path
 from textwrap import dedent
 from typing import TYPE_CHECKING
@@ -13,7 +14,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from check_dependencies.__main__ import _MultiSepAction
+from check_dependencies.__main__ import _get_version, _MultiSepAction
 from check_dependencies.__main__ import main as cli_main
 from check_dependencies.app_config import AppConfig
 from check_dependencies.lib import Dependency, Module, Package, Packages
@@ -78,6 +79,33 @@ def test__main__(monkeypatch: pytest.MonkeyPatch) -> None:
     main_module = Path(__file__).parents[1] / "check_dependencies"
     monkeypatch.setattr("sys.argv", ["check-dependencies", main_module.as_posix()])
     assert cli_main() == 0
+
+
+def test__main__version(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Test the CLI version flag."""
+    monkeypatch.setattr(
+        "check_dependencies.__main__.version", lambda _dist_name: "1.2.3"
+    )
+    monkeypatch.setattr("sys.argv", ["check-dependencies", "--version"])
+
+    with pytest.raises(SystemExit) as exc:
+        cli_main()
+
+    assert exc.value.code == 0
+    assert capsys.readouterr().out == "check-dependencies 1.2.3\n"
+
+
+def test_get_version_without_package_metadata(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Return `unknown` when package metadata is unavailable."""
+
+    def _raise_package_not_found(_dist_name: str) -> str:
+        raise PackageNotFoundError
+
+    monkeypatch.setattr("check_dependencies.__main__.version", _raise_package_not_found)
+
+    assert _get_version() == "unknown"
 
 
 @pytest.mark.parametrize(

--- a/src/tests/test_main.py
+++ b/src/tests/test_main.py
@@ -94,7 +94,8 @@ def test__main__version(
         cli_main()
 
     assert exc.value.code == 0
-    assert capsys.readouterr().out == "check-dependencies 1.2.3\n"
+    assert capsys.readouterr().out.endswith("check-dependencies 1.2.3\n")
+    # .endswith because on Windows this gets prefixed with "python.exe "
 
 
 def test_get_version_without_package_metadata(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/src/tests/test_main.py
+++ b/src/tests/test_main.py
@@ -234,7 +234,7 @@ class TestYieldWrongImports:
         res = self.fn(
             overwrite_cfg=PYPROJECT_EMPTY,
             file_names=[py_file.as_posix()],
-            args="--verbose",
+            args=["--verbose", "--extra=extra1"],
         )
 
         assert len(res) == len(expected)
@@ -655,6 +655,15 @@ class TestMultiSepAction:
         parser = argparse.ArgumentParser()
         with pytest.raises(ValueError, match="type: Only"):
             parser.add_argument("--foo", type=int, action=_MultiSepAction)
+
+    def test_invalid_type_arg(self) -> None:
+        """MultiSepAction with invalid type."""
+        parser = argparse.ArgumentParser()
+        parser.add_argument("--foo", action=_MultiSepAction)
+        action = _MultiSepAction([], "foo", None, str)
+
+        with pytest.raises(TypeError, match="expected a string, got"):
+            action(parser, argparse.Namespace(), [])
 
     @pytest.mark.parametrize("nargs", ["*", "?", "+"])
     def test_invalid_nargs(self, nargs: str) -> None:


### PR DESCRIPTION
This pull request introduces a new `--version` flag to the `check-dependencies` CLI, allowing users to easily check the installed package version. The documentation and help output have been updated to reflect this addition and to clarify several other CLI arguments. 

Additionally, some internal refactoring and test coverage improvements have been made.

**New feature:**

* Added `--version` CLI flag to display the installed package version, with robust handling for missing package metadata. [[1]](diffhunk://#diff-ad19cb6ba0ef334c64c29ed4b1a8ad98b6606e0990cde31ca2ed306b2054d8b7R8) [[2]](diffhunk://#diff-ad19cb6ba0ef334c64c29ed4b1a8ad98b6606e0990cde31ca2ed306b2054d8b7R19-R29) [[3]](diffhunk://#diff-ad19cb6ba0ef334c64c29ed4b1a8ad98b6606e0990cde31ca2ed306b2054d8b7R45-R49) [[4]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR22-R25) [[5]](diffhunk://#diff-24e5bb3549f1f9cf8747aa45c2019439c770d4acd7e36ee319efa978b3c859cbR84-R110) [[6]](diffhunk://#diff-24e5bb3549f1f9cf8747aa45c2019439c770d4acd7e36ee319efa978b3c859cbR9-R17)

**Documentation and CLI improvements:**

* Updated `README.md` usage and help text to include the new `--version` flag and clarified several argument descriptions, including changes to the format and explanation of `--provides`, `--extra`, and `--missing`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L20-R23) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R32-L52)

**Internal refactoring:**

* Refactored how `provides` and `provides_from_venv` arguments are parsed and collected, moving logic into a new `_get_provides` helper function for clarity and maintainability. [[1]](diffhunk://#diff-39024f8a4acf4aa15ff815b88f209b4f9a580958e918ca99be1360cecf828948L70-L78) [[2]](diffhunk://#diff-39024f8a4acf4aa15ff815b88f209b4f9a580958e918ca99be1360cecf828948L120-R113) [[3]](diffhunk://#diff-39024f8a4acf4aa15ff815b88f209b4f9a580958e918ca99be1360cecf828948R163-R175)

**Testing improvements:**

* Added tests for the new `--version` flag and for the case where package metadata is unavailable, ensuring robust behavior. Also improved tests for CLI argument parsing and error handling. [[1]](diffhunk://#diff-24e5bb3549f1f9cf8747aa45c2019439c770d4acd7e36ee319efa978b3c859cbR84-R110) [[2]](diffhunk://#diff-24e5bb3549f1f9cf8747aa45c2019439c770d4acd7e36ee319efa978b3c859cbL209-R237) [[3]](diffhunk://#diff-24e5bb3549f1f9cf8747aa45c2019439c770d4acd7e36ee319efa978b3c859cbR659-R667)

**Miscellaneous:**

* Minor update to the `pyproject.toml` linting task order for consistency.