### PR TITLE
Update build configuration to exclude test files from packaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Exclude `src/tests/**` from source and wheel build artifacts.
+
 ## [1.3. 0] -- 2026-04-06 - Gets provides from virtual environment
 ### Added
 - `check-dependencies --provides-from-venv` to get the --provides entries from a virtual environment

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,7 @@ exclude = ["src/tests/data"]
 
 [tool.pdm.build]
 includes = []
+excludes = ["src/tests/**"]
 
 [build-system]
 requires = ["pdm-backend"]


### PR DESCRIPTION
This pull request updates the build configuration to ensure that test files are excluded from both source and wheel build artifacts. This helps prevent unnecessary files from being included in distributions.

Build configuration updates:

* Updated `pyproject.toml` to exclude all files under `src/tests/**` from build artifacts, ensuring test files are not packaged.
* Updated `CHANGELOG.md` to document the exclusion of `src/tests/**` from source and wheel build artifacts.