### PR TITLE
FIX: dependency-writer: Fix crash if table is between [tool]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Planned
 
 ### Upcoming
+- **FIX**: dependency-writer: Fix intermixing tables in config files ([tool.x]...[other]...[tool.y])
 
 ### [1.4.0] - 2026-04-08 - Show installed package version
 

--- a/src/check_dependencies/writer.py
+++ b/src/check_dependencies/writer.py
@@ -28,6 +28,7 @@ def main() -> int:
     except ValueError as exc:
         print(exc, file=sys.stderr)  # noqa: T201
         return EXIT_VALUE_ERROR
+
     except Exception as exc:  # noqa:BLE001  # pragma: no cover
         print(exc, file=sys.stderr)  # noqa: T201
         return EXIT_FAILURE
@@ -54,7 +55,8 @@ def _update_config(config_file: Path, python: Path) -> None:
     is_stdout = config_file.as_posix() == "-"
 
     cfg = _get_existing_config(config_file, is_stdout=is_stdout)
-    _ensure_key("tool.check-dependencies.provides", cfg)
+
+    _ensure_key(cfg)
     cfg["tool"]["check-dependencies"]["provides"].update(provides)  # type: ignore[not-subscriptable]
     dumps = tomlkit.dumps(cfg)
     if is_stdout:
@@ -76,17 +78,18 @@ def _get_existing_config(config_file: Path, *, is_stdout: bool) -> tomlkit.TOMLD
     return tomlkit.parse(content)
 
 
-def _ensure_key(key: str, doc: MutableMapping) -> None:
+def _ensure_key(cfg: MutableMapping) -> None:
     """Ensure a key exists in a TOML document.
 
     Updates the document in-place!
-    :param key: The key to update in dot-separated format.
-    :param doc: The document to update.
+    :param cfg: The document to update.
     """
-    for key1 in key.split("."):
-        if key1 not in doc:
-            doc[key1] = {}
-        doc = doc[key1]
+    if "tool" not in cfg:
+        cfg["tool"] = {}
+    if "check-dependencies" not in cfg["tool"]:
+        cfg["tool"]["check-dependencies"] = {}
+    if "provides" not in cfg["tool"]["check-dependencies"]:
+        cfg["tool"]["check-dependencies"]["provides"] = {}
 
 
 if __name__ == "__main__":

--- a/src/check_dependencies/writer.py
+++ b/src/check_dependencies/writer.py
@@ -79,9 +79,9 @@ def _get_existing_config(config_file: Path, *, is_stdout: bool) -> tomlkit.TOMLD
 
 
 def _ensure_key(cfg: MutableMapping) -> None:
-    """Ensure a key exists in a TOML document.
+    """Ensure ``tool.check-dependencies.provides`` exists in a TOML document.
 
-    Updates the document in-place!
+    Updates the document in-place.
     :param cfg: The document to update.
     """
     if "tool" not in cfg:

--- a/src/tests/test_writer.py
+++ b/src/tests/test_writer.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import sys
+import textwrap
 from typing import TYPE_CHECKING
 
 import pytest
+import tomlkit
 
-from check_dependencies.writer import EXIT_FAILURE, EXIT_SUCCESS, EXIT_VALUE_ERROR, main
+from check_dependencies import writer
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -27,7 +29,7 @@ def test__main__args__stdout(
         "argv",
         ["check-dependencies", python_switch, sys.executable, cfg_switch, "-"],
     )
-    assert main() == EXIT_SUCCESS
+    assert writer.main() == writer.EXIT_SUCCESS
     stdout = capsys.readouterr().out
     assert "[tool.check-dependencies.provides]\n" in stdout
     assert "pytest = " in stdout
@@ -63,7 +65,7 @@ def test_main__args(
         ],
     )
 
-    assert main() == EXIT_SUCCESS
+    assert writer.main() == writer.EXIT_SUCCESS
     cfg = cfg_file.read_text("utf-8")
     assert "[tool.check-dependencies.provides]\n" in cfg
     assert "pytest = " in cfg
@@ -89,7 +91,7 @@ def test__main__invalid_cfg(
             cfg_file.as_posix(),
         ],
     )
-    assert main() == EXIT_VALUE_ERROR
+    assert writer.main() == writer.EXIT_VALUE_ERROR
     assert 'Invalid key "invalid cfg" at line 1' in capsys.readouterr().err
 
 
@@ -110,12 +112,52 @@ def test__main__cfg_file_is_non_readable(
             tmp_path.as_posix(),
         ],
     )
-    assert main() == EXIT_VALUE_ERROR
+    assert writer.main() == writer.EXIT_VALUE_ERROR
     assert "--config file must be a readable file" in capsys.readouterr().err
 
 
 def test__main__() -> None:
     """Test writer without arguments."""
     with pytest.raises(SystemExit) as exc:
-        main()
-    assert exc.value.code == EXIT_FAILURE
+        writer.main()
+    assert exc.value.code == writer.EXIT_FAILURE
+
+
+def test__ensure_key() -> None:
+    """Test _ensure_key."""
+    doc = tomlkit.parse(
+        textwrap.dedent("""\
+        [tool.a]
+        [fox]
+        [tool.b]
+    """)
+    )
+
+    writer._ensure_key(doc)
+    assert tomlkit.dumps(doc) == textwrap.dedent("""\
+        [tool.a]
+
+        [tool.check-dependencies.provides]
+        [fox]
+        [tool.b]
+    """)
+
+
+def test__ensure_key2() -> None:
+    """Test _ensure_key."""
+    doc = tomlkit.parse(
+        textwrap.dedent("""\
+        [tool.check-dependencies.a]
+        [fox]
+        [tool.check-dependencies.b]
+    """)
+    )
+
+    writer._ensure_key(doc)
+    assert tomlkit.dumps(doc) == textwrap.dedent("""\
+        [tool.check-dependencies.a]
+
+        [tool.check-dependencies.provides]
+        [fox]
+        [tool.check-dependencies.b]
+    """)


### PR DESCRIPTION
This pull request addresses a bug in the dependency writer tool where configuration tables could become intermixed in TOML files, and refactors related code for clarity and robustness. It also updates and extends the test suite to cover these changes.

**Bug Fixes and Core Logic Improvements:**

* Refactored the `_ensure_key` function in `writer.py` to explicitly and robustly ensure the presence of the `tool.check-dependencies.provides` nested tables in the configuration, preventing accidental intermixing of unrelated tables. The function signature was simplified, and the logic now directly checks for and initializes the necessary keys. [[1]](diffhunk://#diff-509e9261653dbe683b355a502bca03e21be71fea2228fed9d1dab16a18b5bad9L57-R59) [[2]](diffhunk://#diff-509e9261653dbe683b355a502bca03e21be71fea2228fed9d1dab16a18b5bad9L79-R92)
* Updated the `_update_config` function to use the new `_ensure_key` signature and logic, ensuring correct table structure before updating the `provides` section.

**Testing and Validation:**

* Added a dedicated test for `_ensure_key` in `test_writer.py` to verify that it correctly initializes the required TOML structure without affecting unrelated tables.
* Refactored test imports and calls to use `writer.main()` and constants, improving clarity and maintainability. [[1]](diffhunk://#diff-1c3fdff6340eecb9cdbf25c4d69a644e336d5fecd936d7050b3e1384f5f6a9bfL7-R10) [[2]](diffhunk://#diff-1c3fdff6340eecb9cdbf25c4d69a644e336d5fecd936d7050b3e1384f5f6a9bfL30-R30) [[3]](diffhunk://#diff-1c3fdff6340eecb9cdbf25c4d69a644e336d5fecd936d7050b3e1384f5f6a9bfL66-R66) [[4]](diffhunk://#diff-1c3fdff6340eecb9cdbf25c4d69a644e336d5fecd936d7050b3e1384f5f6a9bfL92-R92) [[5]](diffhunk://#diff-1c3fdff6340eecb9cdbf25c4d69a644e336d5fecd936d7050b3e1384f5f6a9bfL113-R132)

**Documentation:**

* Added a changelog entry documenting the bug fix for intermixing tables in config files.