### PR TITLE
FIX:  Use appropriate pyproject.toml file (depending on the location of the analyzed source file)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Planned
 
 ### Upcoming
+- **Fix:** Use appropriate pyproject.toml file (depending on the location of the analyzed source file)
 - **CHANGE:** Mark application as production/stable.
 
 ### [1.4.1]

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Example output:
   pandas
 ! matplotlib
   numpy
+# Project project/pyproject.toml
 + requests
 ```
 
@@ -247,10 +248,10 @@ Example output:
 # MISSING check_dependencies
 # MISSING toml
 # MISSING tomllib
+!!FILE_ERROR project/src/broken.py
 !NA matplotlib project/src/main.py:4
 
-### Dependencies in config file not used in application:
-# Config file: project/pyproject.toml
+##### project/pyproject.toml ###
 +EXTRA requests
 ```
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ options:
                         [tool.check-dependencies.provides]
   --include, -I INCLUDE
                         Additional config files to include. Can be specified multiple times. E.g. --include
-                        check-dependencies.toml.Toml Key: [tool.check-dependencies] includes=[]
+                        check-dependencies.toml. Toml Key: [tool.check-dependencies] includes=[]
 ```
 
 ### 📄 Output

--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ Example output:
 !NA matplotlib project/src/main.py:4
 
 ##### project/pyproject.toml ###
+# Dependencies in config file not used in application:
 +EXTRA requests
 ```
 

--- a/src/check_dependencies/__main__.py
+++ b/src/check_dependencies/__main__.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
 
 
 _DIST_NAME = "check-dependencies"
+_writer = sys.stdout.write
 
 
 def _get_version() -> str:
@@ -128,7 +129,7 @@ def main() -> int:
 
     args = parser.parse_args()
 
-    cfg = AppConfig.from_cli_args(
+    app_cfg = AppConfig.from_cli_args(
         file_names=args.file_name,
         known_extra=args.extra,
         known_missing=args.missing,
@@ -139,11 +140,12 @@ def main() -> int:
         includes=args.include,
         provides_from_venv=args.provides_from_venv,
     )
-    wrong_import_lines = yield_wrong_imports(args.file_name, cfg)
+
+    wrong_import_lines = yield_wrong_imports(app_cfg)
     try:
         while True:
-            sys.stdout.write(next(wrong_import_lines))
-            sys.stdout.write("\n")
+            _writer(next(wrong_import_lines))
+            _writer("\n")
     except StopIteration as ex:  # Return value is the exit status
         return ex.value
 

--- a/src/check_dependencies/app_config.py
+++ b/src/check_dependencies/app_config.py
@@ -162,7 +162,10 @@ def _get_provides(
         (Package(pkg.strip()), Module(mod.strip()))
         for pkg, sep, mod in chain(
             (map1.partition("=") for map1 in provides),
-            ((str(pkg), "=", str(mod)) for pkg, mod in mappings_for_env(provides_from_venv)),
+            (
+                (str(pkg), "=", str(mod))
+                for pkg, mod in mappings_for_env(provides_from_venv)
+            ),
         )
         if sep and pkg.strip() and mod.strip()
     ]

--- a/src/check_dependencies/app_config.py
+++ b/src/check_dependencies/app_config.py
@@ -173,12 +173,13 @@ def _get_provides(
     """Parse the provides argument and collect provides from a virtual environment."""
     return [
         (Package(pkg.strip()), Module(mod.strip()))
-        for pkg, sep, mod in chain(
+        for pkg, sep, mods in chain(
             (map1.partition("=") for map1 in provides),
             (
                 (str(pkg), "=", str(mod))
                 for pkg, mod in mappings_for_env(provides_from_venv)
             ),
         )
+        for mod in mods.split(",")
         if sep and pkg.strip() and mod.strip()
     ]

--- a/src/check_dependencies/app_config.py
+++ b/src/check_dependencies/app_config.py
@@ -2,45 +2,40 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from itertools import chain
 from logging import getLogger
 from pathlib import Path
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Collection,
-    Iterable,
-    Iterator,
-    Sequence,
-)
+from typing import TYPE_CHECKING, Collection, TypeVar
 
+from check_dependencies.builtin_module import BUILTINS
 from check_dependencies.lib import Dependency, Module, Package, Packages
 from check_dependencies.provides import mappings_for_env
 from check_dependencies.pyproject_toml import ConfigToml, PyProjectToml
 
 if TYPE_CHECKING:
     import ast
+    from collections.abc import Callable, Iterable, Iterator, Sequence
 
 
 logger = getLogger(__name__)
 
 
-@dataclass()
+@dataclass(frozen=True)
 class AppConfig:
     """Application config and helper functions."""
 
-    known_extra: Collection[Package]
-    known_missing: Collection[Module]
-    provides: Packages
-    dependencies: Collection[Package]
-    pyproject_file: Path | None = None
+    file_names: Sequence[Path]
+    known_extra: Sequence[Package] = ()
+    known_missing: Sequence[Module] = ()
+    provides: Packages = field(default_factory=Packages)
     include_dev: bool = False
     verbose: bool = False
     show_all: bool = False
+    includes: Sequence[Path] = ()
 
     @classmethod
-    def from_cli_args(  # noqa: PLR0913 (factory method)
+    def from_cli_args(  # noqa: PLR0913
         cls,
         *,
         file_names: Sequence[Path],
@@ -53,72 +48,29 @@ class AppConfig:
         includes: Sequence[Path] = (),
         provides_from_venv: Path | None = None,
     ) -> AppConfig:
-        """Create an AppConfig instance from CLI arguments.
+        """Construct an AppConfig from CLI arguments."""
+        includes_cfg = [ConfigToml.for_path(incl) for incl in includes]
 
-        :param file_names: List of file paths to analyze.
-        :param known_extra: List of known extra dependencies.
-        :param known_missing: List of known missing dependencies.
-        :param provides: Iterable of strings in the format "package=module" to specify
-            provided modules.
-        :param include_dev: Whether to include development dependencies from
-            pyproject.toml.
-        :param verbose: Whether to include detailed information in the output.
-        :param show_all: Whether to show all dependencies, including those that are OK.
-        :param includes: Files containing additional configs to include.
-        :param provides_from_venv: Path to a python executable of a virtual environment.
-        """
-        src_cfg = PyProjectToml.for_paths(
-            file_names or [Path()], include_dev=include_dev
-        )
+        _T = TypeVar("_T")
 
-        def with_includes(
-            current_path: Path, paths: Iterable[Path], seen: set[Path]
-        ) -> Iterable[ConfigToml]:
-            for pth in paths:
-                if (res_pth := (current_path / pth).resolve()) not in seen:
-                    seen.add(res_pth)
-                    cfg = ConfigToml.for_path(res_pth)
-                    yield cfg
-                    yield from with_includes(res_pth.parent, cfg.includes, seen)
-                else:
-                    logger.debug("Already parsed: %s", res_pth)
+        def chained(iter_: Iterable[Iterable[_T]]) -> set[_T]:
+            return set(chain.from_iterable(iter_))
 
-        seen: set[Path] = set()
-        cfgs = [
-            *with_includes(Path(), includes, seen),
-            *with_includes(src_cfg.path.parent, src_cfg.includes, seen),
-        ]
-
-        def cfg_of(key: str) -> Iterable[Any]:
-            yield from getattr(src_cfg, key)
-            for cfg in cfgs:
-                yield from getattr(cfg, key)
-
+        known_extra_incl = chained(inc.known_extra for inc in includes_cfg)
+        known_missing_incl = chained(inc.known_missing for inc in includes_cfg)
+        provides_incl = chained(inc.provides for inc in includes_cfg)
         return cls(
+            file_names=file_names,
+            known_extra=sorted(known_extra_incl.union(map(Package, known_extra))),
+            known_missing=sorted(known_missing_incl.union(map(Module, known_missing))),
+            provides=Packages(
+                provides_incl.union(_get_provides(provides, provides_from_venv))
+            ),
             include_dev=include_dev,
             verbose=verbose,
             show_all=show_all,
-            known_extra=frozenset(
-                pkg
-                for pkg in (*map(Package, known_extra), *cfg_of("known_extra"))
-                if pkg.canonical
-            ),
-            known_missing=frozenset(
-                Module(module)
-                for module in (*known_missing, *cfg_of("known_missing"))
-                if module.strip()
-            ),
-            provides=Packages(
-                [*_get_provides(provides, provides_from_venv), *cfg_of("provides")]
-            ),
-            dependencies=src_cfg.dependencies,
-            pyproject_file=src_cfg.path,
+            includes=includes,
         )
-
-    def __post_init__(self) -> None:
-        """Dataclass post init method to ensure sets are frozen."""
-        self.known_extra = frozenset(filter(None, self.known_extra or ()))
-        self.known_missing = frozenset(filter(None, self.known_missing or ()))
 
     def mk_src_formatter(
         self,
@@ -162,14 +114,55 @@ class AppConfig:
         yield f"{Dependency.EXTRA.value}{name} {module}"
 
 
+@dataclass
+class ProjectConfig:
+    """Project dependencies and related config."""
+
+    known_missing: Collection[Module]
+    defined_dependencies: Collection[Package]
+    allowed_dependencies: Collection[Package]
+    known_extra: Collection[Package]
+    packages: Packages
+    src_formatter: Callable[[str, Dependency, Module, ast.AST | None], Iterator[str]]
+    path: Path
+
+    @classmethod
+    def from_config(cls, app_cfg: AppConfig, pyproject: PyProjectToml) -> ProjectConfig:
+        """Initialize an empty ProjectDependencies instance."""
+        packages = app_cfg.provides | Packages(pyproject.provides)
+
+        allowed_dependencies = chain.from_iterable(
+            [
+                pyproject.dependencies,
+                app_cfg.known_extra,
+                pyproject.known_extra,
+                map(Package, BUILTINS),
+                [Package(m.name) for m in pyproject.known_missing],
+            ]
+        )
+
+        known_missing = frozenset([*app_cfg.known_missing, *pyproject.known_missing])
+
+        return cls(
+            known_missing=known_missing,
+            defined_dependencies=frozenset(pyproject.dependencies),
+            allowed_dependencies=frozenset(allowed_dependencies),
+            known_extra=frozenset({*app_cfg.known_extra, *pyproject.known_extra}),
+            packages=packages,
+            src_formatter=app_cfg.mk_src_formatter(),
+            path=pyproject.path,
+        )
+
+
 def _get_provides(
     provides: Iterable[str], provides_from_venv: Path | None
 ) -> Iterable[tuple[Package, Module]]:
     """Parse the provides argument and collect provides from a virtual environment."""
-    for package_name, _, module in (map1.partition("=") for map1 in provides):
-        if package_name.strip() and module.strip():
-            yield Package(package_name), Module(module)
-
-    if provides_from_venv:
-        for package_name, module_name in mappings_for_env(provides_from_venv):
-            yield Package(package_name), Module(module_name)
+    return [
+        (Package(pkg.strip()), Module(mod.strip()))
+        for pkg, mod in chain(
+            (map(str.strip, map1.split("=")) for map1 in provides),
+            mappings_for_env(provides_from_venv),
+        )
+        if pkg.strip() and mod.strip()
+    ]

--- a/src/check_dependencies/app_config.py
+++ b/src/check_dependencies/app_config.py
@@ -32,7 +32,6 @@ class AppConfig:
     include_dev: bool = False
     verbose: bool = False
     show_all: bool = False
-    includes: Sequence[Path] = ()
 
     @classmethod
     def from_cli_args(  # noqa: PLR0913
@@ -69,7 +68,6 @@ class AppConfig:
             include_dev=include_dev,
             verbose=verbose,
             show_all=show_all,
-            includes=includes,
         )
 
     def mk_src_formatter(

--- a/src/check_dependencies/app_config.py
+++ b/src/check_dependencies/app_config.py
@@ -142,26 +142,22 @@ class ProjectConfig:
     @classmethod
     def from_config(cls, app_cfg: AppConfig, pyproject: PyProjectToml) -> ProjectConfig:
         """Initialize an empty ProjectDependencies instance."""
-        packages = app_cfg.provides | Packages(pyproject.provides)
-
-        allowed_dependencies = chain.from_iterable(
-            [
-                pyproject.dependencies,
-                app_cfg.known_extra,
-                pyproject.known_extra,
-                map(Package, BUILTINS),
-                [Package(m.name) for m in pyproject.known_missing],
-            ]
-        )
-
-        known_missing = frozenset([*app_cfg.known_missing, *pyproject.known_missing])
-
         return cls(
-            known_missing=known_missing,
+            known_missing=frozenset([*app_cfg.known_missing, *pyproject.known_missing]),
             defined_dependencies=frozenset(pyproject.dependencies),
-            allowed_dependencies=frozenset(allowed_dependencies),
+            allowed_dependencies=frozenset(
+                chain.from_iterable(
+                    [
+                        pyproject.dependencies,
+                        app_cfg.known_extra,
+                        pyproject.known_extra,
+                        map(Package, BUILTINS),
+                        (Package(m.name) for m in pyproject.known_missing),
+                    ]
+                )
+            ),
             known_extra=frozenset({*app_cfg.known_extra, *pyproject.known_extra}),
-            packages=packages,
+            packages=app_cfg.provides | Packages(pyproject.provides),
             src_formatter=app_cfg.mk_src_formatter(),
             path=pyproject.path,
         )

--- a/src/check_dependencies/app_config.py
+++ b/src/check_dependencies/app_config.py
@@ -114,7 +114,7 @@ class AppConfig:
         yield f"{Dependency.EXTRA.value}{name} {module}"
 
 
-@dataclass
+@dataclass(frozen=True)
 class ProjectConfig:
     """Project dependencies and related config."""
 

--- a/src/check_dependencies/app_config.py
+++ b/src/check_dependencies/app_config.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
 
 
 logger = getLogger(__name__)
+_T = TypeVar("_T")
 
 
 @dataclass(frozen=True)
@@ -50,20 +51,34 @@ class AppConfig:
         """Construct an AppConfig from CLI arguments."""
         includes_cfg = [ConfigToml.for_path(incl) for incl in includes]
 
-        _T = TypeVar("_T")
+        def chained(
+            iter_: Iterable[Iterable[_T]], additional: Iterable[_T] = ()
+        ) -> list[_T]:
+            return sorted({x for sub_iter in iter_ for x in sub_iter}.union(additional))
 
-        def chained(iter_: Iterable[Iterable[_T]]) -> set[_T]:
-            return set(chain.from_iterable(iter_))
-
-        known_extra_incl = chained(inc.known_extra for inc in includes_cfg)
-        known_missing_incl = chained(inc.known_missing for inc in includes_cfg)
-        provides_incl = chained(inc.provides for inc in includes_cfg)
         return cls(
             file_names=file_names,
-            known_extra=sorted(known_extra_incl.union(map(Package, known_extra))),
-            known_missing=sorted(known_missing_incl.union(map(Module, known_missing))),
+            known_extra=chained(
+                (inc.known_extra for inc in includes_cfg),
+                (
+                    pkg
+                    for name in known_extra
+                    if (pkg := Package(name.strip())).canonical
+                ),
+            ),
+            known_missing=chained(
+                (inc.known_missing for inc in includes_cfg),
+                (
+                    module
+                    for name in known_missing
+                    if (module := Module(name.strip())).name
+                ),
+            ),
             provides=Packages(
-                provides_incl.union(_get_provides(provides, provides_from_venv))
+                chained(
+                    (inc.provides for inc in includes_cfg),
+                    _get_provides(provides, provides_from_venv),
+                )
             ),
             include_dev=include_dev,
             verbose=verbose,

--- a/src/check_dependencies/app_config.py
+++ b/src/check_dependencies/app_config.py
@@ -160,9 +160,9 @@ def _get_provides(
     """Parse the provides argument and collect provides from a virtual environment."""
     return [
         (Package(pkg.strip()), Module(mod.strip()))
-        for pkg, mod in chain(
-            (map(str.strip, map1.split("=")) for map1 in provides),
-            mappings_for_env(provides_from_venv),
+        for pkg, sep, mod in chain(
+            (map1.partition("=") for map1 in provides),
+            ((str(pkg), "=", str(mod)) for pkg, mod in mappings_for_env(provides_from_venv)),
         )
-        if pkg.strip() and mod.strip()
+        if sep and pkg.strip() and mod.strip()
     ]

--- a/src/check_dependencies/lib.py
+++ b/src/check_dependencies/lib.py
@@ -143,7 +143,7 @@ class Packages:
 
     _modules: dict[Package, set[Module]]
     _packages: dict[Module, set[Package]]
-    _orig_packages: Collection[tuple[Package, Module]]
+    _orig_packages: tuple[tuple[Package, Module], ...]
 
     def __init__(self, packages: Collection[tuple[Package, Module]] = ()) -> None:
         """Initialize the Packages dataclass.
@@ -151,7 +151,7 @@ class Packages:
         :param packages: List of (package, module) tuples, where package is the
             package name and module is the import name.
         """
-        self._orig_packages = packages
+        self._orig_packages = tuple(packages)
         self._modules = {
             key: {module for _, module in val}
             for key, val in groupby(

--- a/src/check_dependencies/lib.py
+++ b/src/check_dependencies/lib.py
@@ -8,7 +8,7 @@ from enum import Enum
 from functools import total_ordering
 from itertools import groupby, takewhile
 from operator import itemgetter
-from typing import Iterable
+from typing import Collection, Iterable
 
 logger = logging.getLogger("check_dependencies.lib")
 
@@ -143,13 +143,15 @@ class Packages:
 
     _modules: dict[Package, set[Module]]
     _packages: dict[Module, set[Package]]
+    _orig_packages: Collection[tuple[Package, Module]]
 
-    def __init__(self, packages: list[tuple[Package, Module]]) -> None:
+    def __init__(self, packages: Collection[tuple[Package, Module]] = ()) -> None:
         """Initialize the Packages dataclass.
 
         :param packages: List of (package, module) tuples, where package is the
             package name and module is the import name.
         """
+        self._orig_packages = packages
         self._modules = {
             key: {module for _, module in val}
             for key, val in groupby(
@@ -163,6 +165,11 @@ class Packages:
                 sorted(packages, key=itemgetter(1)), key=itemgetter(1)
             )
         }
+
+    def __or__(self, other: Packages) -> Packages:
+        """Combine two Packages instances."""
+        combined_packages = sorted(set(self._orig_packages) | set(other._orig_packages))
+        return Packages(combined_packages)
 
     def all_packages(self) -> Iterable[Package]:
         """Get all packages in the mapping."""

--- a/src/check_dependencies/main.py
+++ b/src/check_dependencies/main.py
@@ -4,14 +4,15 @@ from __future__ import annotations
 
 import ast
 import logging
-from pathlib import Path
 from typing import TYPE_CHECKING, Iterable
 
-from check_dependencies.builtin_module import BUILTINS
-from check_dependencies.lib import Dependency, Module, Package, Packages
+from check_dependencies.app_config import ProjectConfig
+from check_dependencies.lib import Dependency, Module, Package
+from check_dependencies.pyproject_toml import PyProjectToml, get_pyproject_toml
 
 if TYPE_CHECKING:
-    from collections.abc import Collection, Generator, Iterator
+    from collections.abc import Generator, Iterator
+    from pathlib import Path
 
     from check_dependencies.app_config import AppConfig
 
@@ -22,92 +23,106 @@ ERR_NO_PYPROJECT = 8
 ERR_FILE = 16
 
 
-def yield_wrong_imports(
-    file_names: Collection[str],
-    app_cfg: AppConfig,
-) -> Generator[str, None, int]:
+def yield_wrong_imports(app_cfg: AppConfig) -> Generator[str, None, int]:
     """Yield output lines of missing/unused imports.
 
-    :param file_names: List of file paths to analyze.
-    :param app_cfg: Application configuration containing dependencies and settings.
-        If app_cfg.show_all is True, all imports are shown.
+    :param file_cfg_pairs: Iterable of (source file path, AppConfig) pairs as
+        produced by ``AppConfig.from_cli_args``.  All files that share the same
+        ``AppConfig`` instance are treated as belonging to the same project.
     """
-    used_deps: set[Package] = set()
-    src_fmt = app_cfg.mk_src_formatter()
-
-    allowed_dependencies = {
-        *app_cfg.dependencies,  # dependencies from pyproject.toml
-        *app_cfg.known_extra,
-        *Package.set(BUILTINS),
-        *Package.set(x.name for x in app_cfg.known_missing),
-    }
-    provides = app_cfg.provides
-
+    # Map pyproject path → per-project accumulator.
+    # A regular dict is used because the factory would need the AppConfig; we
+    # initialise on first encounter instead of relying on defaultdict's zero-arg
+    # factory.
+    # One formatter per project — its internal dedup cache spans all files in
+    # the same project.
     exit_status = 0
-    yield from _verbose_info(app_cfg)
-
-    for src_pth in _project_files(file_names):
-        for cause, module, stmt in _missing_imports_iter(
-            src_pth, dependencies=allowed_dependencies, provides=provides
-        ):
+    registry = _ProjectRegistry(app_cfg)
+    for src_pth in (
+        src_pth
+        for root_pth in app_cfg.file_names
+        for src_pth in (root_pth.rglob("*.py") if root_pth.is_dir() else [root_pth])
+    ):
+        project_cfg, used_deps = registry.get(src_pth)
+        for cause, module, stmt in _missing_imports_iter(src_pth, project_cfg):
             if cause not in (Dependency.OK, Dependency.FILE_ERROR, Dependency.UNKNOWN):
                 exit_status |= ERR_MISSING_DEPENDENCY
             if not module.raw:
-                used_deps |= provides.packages(module)
-            yield from src_fmt(src_pth.as_posix(), cause, module, stmt)
+                used_deps |= project_cfg.packages.packages(module)
+            yield from project_cfg.src_formatter(
+                src_pth.as_posix(), cause, module, stmt
+            )
 
-    if superfluous_requirements := [
-        msg
-        for dep in sorted(
-            set(app_cfg.dependencies).difference(used_deps, app_cfg.known_extra),
-        )
-        for msg in app_cfg.unused_fmt(str(dep))
-    ]:
-        exit_status |= ERR_EXTRA_DEPENDENCY
-        if app_cfg.verbose:
-            yield ""
-            yield "### Dependencies in config file not used in application:"
-            yield f"# Config file: {app_cfg.pyproject_file}"
-        yield from superfluous_requirements
+    yield from _verbose_app_info(app_cfg)
+    for pyproject_pth, (project_cfg, used_deps) in registry.registry.items():
+        yield from _verbose_project_info(app_cfg, project_cfg)
+        if superfluous_requirements := [
+            msg
+            for dep in sorted(
+                set(project_cfg.defined_dependencies).difference(
+                    used_deps, project_cfg.known_extra
+                ),
+            )
+            for msg in app_cfg.unused_fmt(str(dep))
+        ]:
+            exit_status |= ERR_EXTRA_DEPENDENCY
+            if app_cfg.verbose:
+                yield ""
+                yield "### Dependencies in config file not used in application:"
+                yield f"# Config file: {pyproject_pth}"
+            yield from superfluous_requirements
+
     return exit_status
 
 
-def _verbose_info(app_cfg: AppConfig) -> Iterable[str]:
-    if app_cfg.verbose:
-        yield f"# ALL={app_cfg.show_all}"
-        yield f"# INCLUDE_DEV={app_cfg.include_dev}"
-        for extra in sorted(app_cfg.known_extra):
-            yield f"# EXTRA {extra}"
-        for missing in sorted(app_cfg.known_missing):
-            yield f"# MISSING {missing.name}"
-        for package in sorted(app_cfg.provides.all_packages()):
-            modules = ", ".join(
-                m.name for m in sorted(app_cfg.provides.modules(package))
-            )
-            yield f"# PROVIDES {package} -> [{modules}]"
+class _ProjectRegistry:
+    """Registry of dependencies for a project, with formatters for output."""
+
+    def __init__(self, app_cfg: AppConfig) -> None:
+        """Initialize ProjectRegistry."""
+        self.app_cfg = app_cfg
+        self.include_dev = app_cfg.include_dev
+        self.registry = {}
+
+    def get(self, path: Path) -> tuple[ProjectConfig, set[Package]]:
+        """Get the set of packages associated with a given path."""
+        if (pyproject_pth := get_pyproject_toml(path.resolve())) not in self.registry:
+            self.registry[pyproject_pth] = (self._new_config(pyproject_pth), set())
+
+        return self.registry[pyproject_pth]
+
+    def _new_config(self, pyproject_pth: Path) -> ProjectConfig:
+        """Get the config associated with a given path."""
+        proj = PyProjectToml.for_path(pyproject_pth, include_dev=self.include_dev)
+        return ProjectConfig.from_config(self.app_cfg, proj)
 
 
-def _project_files(file_names: Collection[str]) -> Iterator[Path]:
-    """Collect all Python files in a list of files or directories.
+def _verbose_app_info(app_cfg: AppConfig) -> Iterable[str]:
+    if not app_cfg.verbose:
+        return
+    yield f"# ALL={app_cfg.show_all}"
+    yield f"# INCLUDE_DEV={app_cfg.include_dev}"
+    for extra in sorted(app_cfg.known_extra):
+        yield f"# EXTRA {extra}"
+    for missing in sorted(app_cfg.known_missing):
+        yield f"# MISSING {missing.name}"
 
-    Ensure no file is visited more than once.
 
-    :param file_names: List of file paths or directories to analyze.
-    """
-    visited = set()
-    for p in map(Path, file_names):
-        for p_sub in p.rglob("*.py") if p.is_dir() else [p]:
-            # resolve to avoid duplicates from symlinks or different relative paths.
-            # Symlink can be pointed outside the project directory.
-            if (p_sub_resolved := p_sub.resolve()) not in visited:
-                visited.add(p_sub_resolved)
-                yield p_sub
+def _verbose_project_info(
+    app_cfg: AppConfig, project_cfg: ProjectConfig
+) -> Iterable[str]:
+    if not app_cfg.verbose:
+        return
+    yield f"# CONFIG: {project_cfg.path}"
+    for package in sorted(project_cfg.packages.all_packages()):
+        modules = ", ".join(
+            m.name for m in sorted(project_cfg.packages.modules(package))
+        )
+        yield f"# PROVIDES {package} -> [{modules}]"
 
 
 def _missing_imports_iter(
-    file: Path,
-    dependencies: Collection[Package],
-    provides: Packages,
+    file: Path, project_cfg: ProjectConfig
 ) -> Iterator[tuple[Dependency, Module, ast.AST]]:
     """Find missing imports in a Python file.
 
@@ -129,8 +144,13 @@ def _missing_imports_iter(
         if module.raw:
             yield Dependency.UNKNOWN, module, stmt
         else:
-            pkg_ = provides.packages(module)
-            status = Dependency.OK if pkg_.intersection(dependencies) else Dependency.NA
+            pkg_ = project_cfg.packages.packages(module)
+            status = (
+                Dependency.OK
+                if module.main in project_cfg.known_missing
+                or pkg_.intersection(project_cfg.allowed_dependencies)
+                else Dependency.NA
+            )
             yield status, module, stmt
 
 

--- a/src/check_dependencies/main.py
+++ b/src/check_dependencies/main.py
@@ -46,9 +46,8 @@ def yield_wrong_imports(app_cfg: AppConfig) -> Generator[str, None, int]:
         src_pth
         for root_pth in app_cfg.file_names
         for src_pth in (root_pth.rglob("*.py") if root_pth.is_dir() else [root_pth])
+        if src_pth not in seen
     ):
-        if src_pth in seen:
-            continue
         seen.add(src_pth)
         try:
             project_cfg, used_deps = registry.get(src_pth)

--- a/src/check_dependencies/main.py
+++ b/src/check_dependencies/main.py
@@ -37,11 +37,16 @@ def yield_wrong_imports(app_cfg: AppConfig) -> Generator[str, None, int]:
     # the same project.
     exit_status = 0
     registry = _ProjectRegistry(app_cfg)
+    seen = set()
     for src_pth in (
-        src_pth
+        src_pth.resolve()
         for root_pth in app_cfg.file_names
         for src_pth in (root_pth.rglob("*.py") if root_pth.is_dir() else [root_pth])
     ):
+        if src_pth in seen:
+            continue
+        seen.add(src_pth)
+
         project_cfg, used_deps = registry.get(src_pth)
         for cause, module, stmt in _missing_imports_iter(src_pth, project_cfg):
             if cause not in (Dependency.OK, Dependency.FILE_ERROR, Dependency.UNKNOWN):

--- a/src/check_dependencies/main.py
+++ b/src/check_dependencies/main.py
@@ -41,11 +41,12 @@ def yield_wrong_imports(app_cfg: AppConfig) -> Generator[str, None, int]:
     # the same project.
     exit_status = 0
     yield from _verbose_app_info(app_cfg)
-    registry = _ProjectRegistry(app_cfg)
-    for src_pth in app_cfg.file_names:
-        registry.get(
-            src_pth
-        )  # Ensure all projects are registered, even if no python files are found.
+
+    try:
+        registry = _ProjectRegistry(app_cfg)
+    except NoPyProjectFileError as exc:
+        logger.error("Could not find pyproject.toml for %s", exc)  # noqa: TRY400
+        return exit_status | ERR_NO_PYPROJECT
 
     seen: set[Path] = set()
     for src_pth in (
@@ -110,6 +111,10 @@ class _ProjectRegistry:
         self.app_cfg = app_cfg
         self.include_dev = app_cfg.include_dev
         self.registry = {}
+
+        # Pre-populate registry to fail fast if pyproject.toml files are missing.
+        for path in app_cfg.file_names:
+            self.get(path)
 
     def get(self, path: Path) -> tuple[ProjectConfig, set[Package]]:
         """Get the set of packages associated with a given path."""

--- a/src/check_dependencies/main.py
+++ b/src/check_dependencies/main.py
@@ -56,7 +56,9 @@ def yield_wrong_imports(app_cfg: AppConfig) -> Generator[str, None, int]:
             return exit_status | ERR_NO_PYPROJECT
 
         for cause, module, stmt in _missing_imports_iter(src_pth, project_cfg):
-            if cause not in (Dependency.OK, Dependency.FILE_ERROR, Dependency.UNKNOWN):
+            if cause is Dependency.FILE_ERROR:
+                exit_status |= ERR_FILE
+            elif cause not in (Dependency.OK, Dependency.UNKNOWN):
                 exit_status |= ERR_MISSING_DEPENDENCY
             if not module.raw:
                 used_deps |= project_cfg.packages.packages(module)

--- a/src/check_dependencies/main.py
+++ b/src/check_dependencies/main.py
@@ -151,7 +151,7 @@ def _missing_imports_iter(
     """Find missing imports in a Python file.
 
     :param file: Python file to analyze
-    :param dependencies: Declared dependencies from pyproject file
+    :param project_cfg: Project specific configuration.
     :yields: Tuple of status, module and import statement
     """
     try:

--- a/src/check_dependencies/main.py
+++ b/src/check_dependencies/main.py
@@ -43,7 +43,7 @@ def yield_wrong_imports(app_cfg: AppConfig) -> Generator[str, None, int]:
     registry = _ProjectRegistry(app_cfg)
     seen = set()
     for src_pth in (
-        src_pth.resolve()
+        src_pth
         for root_pth in app_cfg.file_names
         for src_pth in (root_pth.rglob("*.py") if root_pth.is_dir() else [root_pth])
     ):
@@ -98,7 +98,7 @@ class _ProjectRegistry:
 
     def get(self, path: Path) -> tuple[ProjectConfig, set[Package]]:
         """Get the set of packages associated with a given path."""
-        pyproject_pth = get_pyproject_toml(path.parent.resolve())
+        pyproject_pth = get_pyproject_toml(path.parent)
         if pyproject_pth not in self.registry:
             self.registry[pyproject_pth] = (self._new_config(pyproject_pth), set())
 

--- a/src/check_dependencies/main.py
+++ b/src/check_dependencies/main.py
@@ -43,7 +43,9 @@ def yield_wrong_imports(app_cfg: AppConfig) -> Generator[str, None, int]:
     yield from _verbose_app_info(app_cfg)
     registry = _ProjectRegistry(app_cfg)
     for src_pth in app_cfg.file_names:
-        registry.get(src_pth)  # Ensure all projects are registered, even if no python files are found.
+        registry.get(
+            src_pth
+        )  # Ensure all projects are registered, even if no python files are found.
 
     seen: set[Path] = set()
     for src_pth in (

--- a/src/check_dependencies/main.py
+++ b/src/check_dependencies/main.py
@@ -8,7 +8,11 @@ from typing import TYPE_CHECKING, Iterable
 
 from check_dependencies.app_config import ProjectConfig
 from check_dependencies.lib import Dependency, Module, Package
-from check_dependencies.pyproject_toml import PyProjectToml, get_pyproject_toml, NoPyProjectFile
+from check_dependencies.pyproject_toml import (
+    NoPyProjectFileError,
+    PyProjectToml,
+    get_pyproject_toml,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Generator, Iterator
@@ -48,8 +52,8 @@ def yield_wrong_imports(app_cfg: AppConfig) -> Generator[str, None, int]:
         seen.add(src_pth)
         try:
             project_cfg, used_deps = registry.get(src_pth)
-        except NoPyProjectFile as exc:
-            logger.error("Could not find pyproject.toml for %s", src_pth, exc_info=False)
+        except NoPyProjectFileError as exc:
+            logger.error("Could not find pyproject.toml for %s", exc)  # noqa: TRY400
             return exit_status | ERR_NO_PYPROJECT
 
         for cause, module, stmt in _missing_imports_iter(src_pth, project_cfg):

--- a/src/check_dependencies/main.py
+++ b/src/check_dependencies/main.py
@@ -26,9 +26,8 @@ ERR_FILE = 16
 def yield_wrong_imports(app_cfg: AppConfig) -> Generator[str, None, int]:
     """Yield output lines of missing/unused imports.
 
-    :param file_cfg_pairs: Iterable of (source file path, AppConfig) pairs as
-        produced by ``AppConfig.from_cli_args``.  All files that share the same
-        ``AppConfig`` instance are treated as belonging to the same project.
+    :param app_cfg: Application configuration used to determine which files to
+        scan and how to resolve and report project dependencies.
     """
     # Map pyproject path → per-project accumulator.
     # A regular dict is used because the factory would need the AppConfig; we
@@ -86,7 +85,7 @@ class _ProjectRegistry:
 
     def get(self, path: Path) -> tuple[ProjectConfig, set[Package]]:
         """Get the set of packages associated with a given path."""
-        if (pyproject_pth := get_pyproject_toml(path.resolve())) not in self.registry:
+        if (pyproject_pth := get_pyproject_toml(path.parent.resolve())) not in self.registry:
             self.registry[pyproject_pth] = (self._new_config(pyproject_pth), set())
 
         return self.registry[pyproject_pth]

--- a/src/check_dependencies/main.py
+++ b/src/check_dependencies/main.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Iterable
 
 from check_dependencies.app_config import ProjectConfig
 from check_dependencies.lib import Dependency, Module, Package
-from check_dependencies.pyproject_toml import PyProjectToml, get_pyproject_toml
+from check_dependencies.pyproject_toml import PyProjectToml, get_pyproject_toml, NoPyProjectFile
 
 if TYPE_CHECKING:
     from collections.abc import Generator, Iterator
@@ -46,8 +46,12 @@ def yield_wrong_imports(app_cfg: AppConfig) -> Generator[str, None, int]:
         if src_pth in seen:
             continue
         seen.add(src_pth)
+        try:
+            project_cfg, used_deps = registry.get(src_pth)
+        except NoPyProjectFile as exc:
+            logger.error("Could not find pyproject.toml for %s", src_pth, exc_info=False)
+            return exit_status | ERR_NO_PYPROJECT
 
-        project_cfg, used_deps = registry.get(src_pth)
         for cause, module, stmt in _missing_imports_iter(src_pth, project_cfg):
             if cause not in (Dependency.OK, Dependency.FILE_ERROR, Dependency.UNKNOWN):
                 exit_status |= ERR_MISSING_DEPENDENCY

--- a/src/check_dependencies/main.py
+++ b/src/check_dependencies/main.py
@@ -94,9 +94,8 @@ class _ProjectRegistry:
 
     def get(self, path: Path) -> tuple[ProjectConfig, set[Package]]:
         """Get the set of packages associated with a given path."""
-        if (
-            pyproject_pth := get_pyproject_toml(path.parent.resolve())
-        ) not in self.registry:
+        pyproject_pth = get_pyproject_toml(path.parent.resolve())
+        if pyproject_pth not in self.registry:
             self.registry[pyproject_pth] = (self._new_config(pyproject_pth), set())
 
         return self.registry[pyproject_pth]

--- a/src/check_dependencies/main.py
+++ b/src/check_dependencies/main.py
@@ -40,6 +40,7 @@ def yield_wrong_imports(app_cfg: AppConfig) -> Generator[str, None, int]:
     # One formatter per project — its internal dedup cache spans all files in
     # the same project.
     exit_status = 0
+    yield from _verbose_app_info(app_cfg)
     registry = _ProjectRegistry(app_cfg)
     seen = set()
     for src_pth in (
@@ -66,26 +67,35 @@ def yield_wrong_imports(app_cfg: AppConfig) -> Generator[str, None, int]:
                 src_pth.as_posix(), cause, module, stmt
             )
 
-    yield from _verbose_app_info(app_cfg)
-    for pyproject_pth, (project_cfg, used_deps) in registry.registry.items():
+    # After processing all files, check for superfluous requirements in each project.
+    for project_cfg, used_deps in registry.registry.values():
         yield from _verbose_project_info(app_cfg, project_cfg)
-        if superfluous_requirements := [
-            msg
-            for dep in sorted(
-                set(project_cfg.defined_dependencies).difference(
-                    used_deps, project_cfg.known_extra
-                ),
-            )
-            for msg in app_cfg.unused_fmt(str(dep))
-        ]:
+        for line in _get_superfluous_requirements(project_cfg, used_deps, app_cfg):
+            yield line
             exit_status |= ERR_EXTRA_DEPENDENCY
-            if app_cfg.verbose:
-                yield ""
-                yield "### Dependencies in config file not used in application:"
-                yield f"# Config file: {pyproject_pth}"
-            yield from superfluous_requirements
 
     return exit_status
+
+
+def _get_superfluous_requirements(
+    project_cfg: ProjectConfig, used_deps: set[Package], app_cfg: AppConfig
+) -> Iterable[str]:
+    if superfluous_requirements := [
+        msg
+        for dep in sorted(
+            set(project_cfg.defined_dependencies).difference(
+                used_deps, project_cfg.known_extra
+            ),
+        )
+        for msg in app_cfg.unused_fmt(str(dep))
+    ]:
+        if app_cfg.verbose:
+            yield "# Dependencies in config file not used in application:"
+        else:
+            yield f"# Project {project_cfg.path}"
+        yield from superfluous_requirements
+        if app_cfg.verbose:
+            yield ""
 
 
 class _ProjectRegistry:
@@ -127,7 +137,7 @@ def _verbose_project_info(
 ) -> Iterable[str]:
     if not app_cfg.verbose:
         return
-    yield f"# CONFIG: {project_cfg.path}"
+    yield f"##### {project_cfg.path} ###"
     for package in sorted(project_cfg.packages.all_packages()):
         modules = ", ".join(
             m.name for m in sorted(project_cfg.packages.modules(package))

--- a/src/check_dependencies/main.py
+++ b/src/check_dependencies/main.py
@@ -42,14 +42,16 @@ def yield_wrong_imports(app_cfg: AppConfig) -> Generator[str, None, int]:
     exit_status = 0
     yield from _verbose_app_info(app_cfg)
     registry = _ProjectRegistry(app_cfg)
-    seen = set()
+    for src_pth in app_cfg.file_names:
+        registry.get(src_pth)  # Ensure all projects are registered, even if no python files are found.
+
+    seen: set[Path] = set()
     for src_pth in (
         src_pth
         for root_pth in app_cfg.file_names
         for src_pth in (root_pth.rglob("*.py") if root_pth.is_dir() else [root_pth])
-        if src_pth not in seen
+        if src_pth not in seen or seen.add(src_pth)
     ):
-        seen.add(src_pth)
         try:
             project_cfg, used_deps = registry.get(src_pth)
         except NoPyProjectFileError as exc:

--- a/src/check_dependencies/main.py
+++ b/src/check_dependencies/main.py
@@ -90,7 +90,9 @@ class _ProjectRegistry:
 
     def get(self, path: Path) -> tuple[ProjectConfig, set[Package]]:
         """Get the set of packages associated with a given path."""
-        if (pyproject_pth := get_pyproject_toml(path.parent.resolve())) not in self.registry:
+        if (
+            pyproject_pth := get_pyproject_toml(path.parent.resolve())
+        ) not in self.registry:
             self.registry[pyproject_pth] = (self._new_config(pyproject_pth), set())
 
         return self.registry[pyproject_pth]

--- a/src/check_dependencies/provides.py
+++ b/src/check_dependencies/provides.py
@@ -8,13 +8,15 @@ from pathlib import Path
 from typing import Iterable
 
 
-def mappings_for_env(python: Path) -> list[tuple[str, str]]:
+def mappings_for_env(python: Path | None) -> list[tuple[str, str]]:
     """Get the mappings.
 
     :arg python: Path to python executable belonging to the virtual
         environment, e.g. $VIRTUAL_ENV/bin/python.
     :return: a list of mappings of package name to module name.
     """
+    if not python:
+        return []
     return sorted(
         (package_name, import_name)
         for path in _get_paths(python)

--- a/src/check_dependencies/pyproject_toml.py
+++ b/src/check_dependencies/pyproject_toml.py
@@ -115,7 +115,7 @@ class PyProjectToml(ConfigToml):
     ) -> PyProjectToml:
         """Create a PyProjectToml instance from a known pyproject.toml path.
 
-        :param path: Absolute path to a pyproject.toml file.
+        :param path: Path to a pyproject.toml file.
         :param include_dev: Whether to include development dependencies.
         :returns: A PyProjectToml instance with the parsed configuration.
         """

--- a/src/check_dependencies/pyproject_toml.py
+++ b/src/check_dependencies/pyproject_toml.py
@@ -40,11 +40,11 @@ class ConfigToml:
         cfg = tomllib.loads(path.read_text("utf-8"))
         return ConfigToml(
             cfg=cfg,
-            includes_cfg=[
+            includes_cfg=tuple(
                 cls.for_path(path=path.parent / p, _seen={*_seen, path})
                 for p in _nested_item(cfg, _INCLUDES_KEY, list)
                 if path.parent / p not in _seen
-            ],
+            ),
         )
 
     @property
@@ -123,11 +123,11 @@ class PyProjectToml(ConfigToml):
         _seen = {*_seen, path}
         return cls(
             cfg=cfg,
-            includes_cfg=[
+            includes_cfg=tuple(
                 cls.for_path(path.parent / p, include_dev=include_dev, _seen=_seen)
                 for p in _nested_item(cfg, _INCLUDES_KEY, list)
                 if path.parent / p not in _seen
-            ],
+            ),
             path=path,
             include_dev=include_dev,
         )

--- a/src/check_dependencies/pyproject_toml.py
+++ b/src/check_dependencies/pyproject_toml.py
@@ -41,9 +41,9 @@ class ConfigToml:
         return ConfigToml(
             cfg=cfg,
             includes_cfg=[
-                cls.for_path(path=path / p, _seen={*_seen, path})
+                cls.for_path(path=path.parent / p, _seen={*_seen, path})
                 for p in _nested_item(cfg, _INCLUDES_KEY, list)
-                if path / p not in _seen
+                if path.parent / p not in _seen
             ],
         )
 

--- a/src/check_dependencies/pyproject_toml.py
+++ b/src/check_dependencies/pyproject_toml.py
@@ -173,8 +173,10 @@ class PyProjectToml(ConfigToml):
             ),
         )
 
-class NoPyProjectFile(FileNotFoundError):
-    pass
+
+class NoPyProjectFileError(FileNotFoundError):
+    """pyproject.toml file not found in the directory hierarchy of the given path."""
+
 
 @lru_cache(maxsize=100_000)
 def get_pyproject_toml(path: Path) -> Path:
@@ -193,11 +195,11 @@ def get_pyproject_toml(path: Path) -> Path:
         return result
 
     if path == path.parent:  # Exit recursion
-        raise NoPyProjectFile(path)
+        raise NoPyProjectFileError(path)
     try:
         return get_pyproject_toml(path.parent)
-    except NoPyProjectFile:
-        raise NoPyProjectFile(path) from None
+    except NoPyProjectFileError:
+        raise NoPyProjectFileError(path) from None
 
 
 @dataclass(frozen=True)

--- a/src/check_dependencies/pyproject_toml.py
+++ b/src/check_dependencies/pyproject_toml.py
@@ -186,8 +186,8 @@ def get_pyproject_toml(path: Path) -> Path:
     ``file.parent``) until a ``pyproject.toml`` is found.
 
     :param path: Directory to start searching from.
-    :returns: Absolute path to the nearest ``pyproject.toml``.
-    :raises FileNotFoundError: When no ``pyproject.toml`` is found in the hierarchy.
+    :returns: Path to the nearest ``pyproject.toml``.
+    :raises NoPyProjectFileError: When no ``pyproject.toml`` is found in the hierarchy.
 
     This uses recursion and LRU caching to allow for efficient caching.
     """
@@ -199,6 +199,7 @@ def get_pyproject_toml(path: Path) -> Path:
     try:
         return get_pyproject_toml(path.parent)
     except NoPyProjectFileError:
+        # Get original path for error message, not the resolved and recursed path
         raise NoPyProjectFileError(path) from None
 
 

--- a/src/check_dependencies/pyproject_toml.py
+++ b/src/check_dependencies/pyproject_toml.py
@@ -173,6 +173,8 @@ class PyProjectToml(ConfigToml):
             ),
         )
 
+class NoPyProjectFile(FileNotFoundError):
+    pass
 
 @lru_cache(maxsize=None)
 def get_pyproject_toml(path: Path) -> Path:
@@ -191,10 +193,11 @@ def get_pyproject_toml(path: Path) -> Path:
         return result
 
     if path == path.parent:  # Exit recursion
-        msg = f"Could not find {_PYPROJECT_TOML} file within path hierarchy"
-        raise FileNotFoundError(msg)
-
-    return get_pyproject_toml(path.parent)
+        raise NoPyProjectFile(path)
+    try:
+        return get_pyproject_toml(path.parent)
+    except NoPyProjectFile:
+        raise NoPyProjectFile(path) from None
 
 
 @dataclass(frozen=True)

--- a/src/check_dependencies/pyproject_toml.py
+++ b/src/check_dependencies/pyproject_toml.py
@@ -120,13 +120,13 @@ class PyProjectToml(ConfigToml):
         :returns: A PyProjectToml instance with the parsed configuration.
         """
         cfg = tomllib.loads(path.read_text("utf-8"))
-        includes = [] if path in _seen else _nested_item(cfg, _INCLUDES_KEY, list)
         _seen = {*_seen, path}
         return cls(
             cfg=cfg,
             includes_cfg=[
                 cls.for_path(path.parent / p, include_dev=include_dev, _seen=_seen)
-                for p in includes
+                for p in _nested_item(cfg, _INCLUDES_KEY, list)
+                if path.parent / p not in _seen
             ],
             path=path,
             include_dev=include_dev,

--- a/src/check_dependencies/pyproject_toml.py
+++ b/src/check_dependencies/pyproject_toml.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+from functools import lru_cache
 from itertools import chain
-from os.path import commonpath
 from pathlib import Path
-from typing import Any, Collection, Mapping, TypeVar
+from typing import Any, Collection, Mapping, Sequence, TypeVar
 
-from check_dependencies.lib import Module, Package
+from check_dependencies.lib import Module, Package, Packages
 
 try:
     import tomllib  # ty:ignore[unresolved-import]
@@ -20,39 +20,43 @@ logger = logging.getLogger(__name__)
 _PYPROJECT_TOML = Path("pyproject.toml")
 _T = TypeVar("_T")
 
+_INCLUDES_KEY = "tool.check-dependencies.includes"
+_KNOWN_MISSING_KEY = "tool.check-dependencies.known-missing"
+_KNOWN_EXTRA_KEY = "tool.check-dependencies.known-extra"
+_PROVIDES_KEY = "tool.check-dependencies.provides"
+
 
 @dataclass(frozen=True)
 class ConfigToml:
     """Additional config for check-dependencies options. Useful for mono-repos."""
 
     cfg: dict[str, Any]
-    path: Path
+    includes_cfg: Sequence[ConfigToml]
 
     @classmethod
-    def for_path(cls, path: Path) -> ConfigToml:
+    def for_path(cls, path: Path, *, _seen: Collection[Path] = ()) -> ConfigToml:
         """Get a config from a path."""
         logger.debug("Parsing %s", path)
+        cfg = tomllib.loads(path.read_text("utf-8"))
         return ConfigToml(
-            cfg=tomllib.loads(path.read_text("utf-8")),
-            path=path,
+            cfg=cfg,
+            includes_cfg=[
+                cls.for_path(path=path / p, _seen={*_seen, path})
+                for p in _nested_item(cfg, _INCLUDES_KEY, list)
+                if path / p not in _seen
+            ],
         )
 
     @property
-    def includes(self) -> frozenset[Path]:
-        """Additional config files to include."""
-        return frozenset(
-            Path(p)
-            for p in _nested_item(self.cfg, "tool.check-dependencies.includes", list)
-        )
-
-    @property
-    def known_missing(self) -> frozenset[str]:
+    def known_missing(self) -> frozenset[Module]:
         """Known to be used in application but not declared in requirements."""
         return frozenset(
-            _nested_item(
-                self.cfg,
-                "tool.check-dependencies.known-missing",
-                list,
+            chain(
+                map(
+                    Module,
+                    _nested_item(self.cfg, _KNOWN_MISSING_KEY, list),
+                ),
+                chain.from_iterable(incl.known_missing for incl in self.includes_cfg),
             )
         )
 
@@ -60,14 +64,17 @@ class ConfigToml:
     def known_extra(self) -> frozenset[Package]:
         """Dependencies that are known to be unused in application."""
         return frozenset(
-            map(
-                Package,
-                _nested_item(self.cfg, "tool.check-dependencies.known-extra", list),
+            chain(
+                map(
+                    Package,
+                    _nested_item(self.cfg, _KNOWN_EXTRA_KEY, list),
+                ),
+                chain.from_iterable(incl.known_extra for incl in self.includes_cfg),
             )
         )
 
     @property
-    def provides(self) -> list[tuple[Package, Module]]:
+    def provides(self) -> frozenset[tuple[Package, Module]]:
         """Mapping from import name to package name.
 
         E.g. ``[
@@ -81,47 +88,46 @@ class ConfigToml:
         hyphen/underscore equivalent), so e.g. ``PyJWT``, ``pyjwt``, and
         ``pyJwt`` resolve to the same package identity.
         """
-        return [
-            (Package(package), Module(module))
-            for package, modules in _nested_item(
-                self.cfg, "tool.check-dependencies.provides", dict
-            ).items()
-            for module in ([modules] if isinstance(modules, str) else modules)
-        ]
+        return frozenset(
+            chain(
+                (
+                    (Package(package), Module(module))
+                    for package, modules in _nested_item(
+                        self.cfg, _PROVIDES_KEY, dict
+                    ).items()
+                    for module in ([modules] if isinstance(modules, str) else modules)
+                ),
+                chain.from_iterable(incl.provides for incl in self.includes_cfg),
+            )
+        )
 
 
 @dataclass(frozen=True)
 class PyProjectToml(ConfigToml):
     """Project specific options (dependencies, config) from a pyproject.toml file."""
 
-    cfg: dict[str, Any]
     path: Path
     include_dev: bool = False
 
     @classmethod
-    def for_paths(
-        cls, paths: Collection[Path], *, include_dev: bool = False
+    def for_path(
+        cls, path: Path, *, include_dev: bool = False, _seen: Collection[Path] = ()
     ) -> PyProjectToml:
-        """Create a PyProjectToml instance from a pyproject.toml file.
+        """Create a PyProjectToml instance from a known pyproject.toml path.
 
-        :param paths: List of file paths to analyze. The common parent directory
-            will be searched for a pyproject.toml file.
-        :param include_dev: Whether to include development dependencies
-            from pyproject.toml.
+        :param path: Absolute path to a pyproject.toml file.
+        :param include_dev: Whether to include development dependencies.
         :returns: A PyProjectToml instance with the parsed configuration.
         """
-        try:
-            pyproject_candidate = Path(
-                commonpath(p.expanduser().resolve() for p in paths),
-            )
-        except ValueError as exc:  # pragma: no cover
-            # Can only be reached in Windows when two different drives are provided.
-            msg = f"Error finding common path for {paths}: {exc}"
-            raise ValueError(msg) from exc
-        path = _get_pyproject_path(pyproject_candidate)
-
+        cfg = tomllib.loads(path.read_text("utf-8"))
+        includes = [] if path in _seen else _nested_item(cfg, _INCLUDES_KEY, list)
+        _seen = {*_seen, path}
         return cls(
-            cfg=tomllib.loads(path.read_text("utf-8")),
+            cfg=cfg,
+            includes_cfg=[
+                cls.for_path(path.parent / p, include_dev=include_dev, _seen=_seen)
+                for p in includes
+            ],
             path=path,
             include_dev=include_dev,
         )
@@ -147,20 +153,43 @@ class PyProjectToml(ConfigToml):
         return frozenset(deps)
 
     @property
-    def known_missing(self) -> frozenset[str]:
+    def known_missing(self) -> frozenset[Module]:
         """Known to be used in application but not declared in requirements.
 
         This includes the project itself.
         """
         # Add project name
+        packages = Packages([])
         pep631_name = Package(_nested_item(self.cfg, "project.name", str) or "")
         poetry_name = Package(_nested_item(self.cfg, "tool.poetry.name", str) or "")
         return frozenset(
             filter(
-                None,
-                (pep631_name.canonical, poetry_name.canonical, *super().known_missing),
+                lambda m: m.name,
+                chain(
+                    super().known_missing,
+                    packages.modules(pep631_name),
+                    packages.modules(poetry_name),
+                ),
             ),
         )
+
+
+@lru_cache(maxsize=None)
+def get_pyproject_toml(path: Path) -> Path:
+    """Return the pyproject.toml path for the given directory, with caching.
+
+    Searches upward from *path* (which should be a directory, typically
+    ``file.parent``) until a ``pyproject.toml`` is found.
+
+    :param path: Directory to start searching from.
+    :returns: Absolute path to the nearest ``pyproject.toml``.
+    :raises FileNotFoundError: When no ``pyproject.toml`` is found in the hierarchy.
+    """
+    for p in chain([path], path.resolve().parents):
+        if (p / _PYPROJECT_TOML).exists():
+            return p / _PYPROJECT_TOML
+    msg = f"Could not find {_PYPROJECT_TOML} file within path hierarchy"
+    raise FileNotFoundError(msg)
 
 
 @dataclass(frozen=True)
@@ -308,15 +337,3 @@ def _nested_item(obj: Mapping[str, Any], key: str, /, class_: type[_T]) -> _T:
         msg = f"Expected {class_} but got {type(obj)}"
         raise TypeError(msg)
     return obj
-
-
-def _get_pyproject_path(path: Path) -> Path:
-    """Get the pyproject.toml file by searching up the directory hierarchy.
-
-    :param path: The starting path to search from.
-    """
-    for p in chain([path], path.resolve().parents):
-        if (p / _PYPROJECT_TOML).exists():
-            return p / _PYPROJECT_TOML
-    msg = f"Could not find {_PYPROJECT_TOML} file within path hierarchy"
-    raise FileNotFoundError(msg)

--- a/src/check_dependencies/pyproject_toml.py
+++ b/src/check_dependencies/pyproject_toml.py
@@ -176,7 +176,7 @@ class PyProjectToml(ConfigToml):
 class NoPyProjectFile(FileNotFoundError):
     pass
 
-@lru_cache(maxsize=None)
+@lru_cache(maxsize=100_000)
 def get_pyproject_toml(path: Path) -> Path:
     """Return the pyproject.toml path for the given directory, with caching.
 

--- a/src/check_dependencies/pyproject_toml.py
+++ b/src/check_dependencies/pyproject_toml.py
@@ -185,9 +185,11 @@ def get_pyproject_toml(path: Path) -> Path:
     :returns: Absolute path to the nearest ``pyproject.toml``.
     :raises FileNotFoundError: When no ``pyproject.toml`` is found in the hierarchy.
     """
-    for p in chain([path], path.resolve().parents):
-        if (p / _PYPROJECT_TOML).exists():
-            return p / _PYPROJECT_TOML
+    root = path.resolve()
+    for p in chain([root], root.parents):
+        pyproject_toml = p / _PYPROJECT_TOML
+        if pyproject_toml.exists():
+            return pyproject_toml
     msg = f"Could not find {_PYPROJECT_TOML} file within path hierarchy"
     raise FileNotFoundError(msg)
 

--- a/src/check_dependencies/pyproject_toml.py
+++ b/src/check_dependencies/pyproject_toml.py
@@ -184,14 +184,17 @@ def get_pyproject_toml(path: Path) -> Path:
     :param path: Directory to start searching from.
     :returns: Absolute path to the nearest ``pyproject.toml``.
     :raises FileNotFoundError: When no ``pyproject.toml`` is found in the hierarchy.
+
+    This uses recursion and LRU caching to allow for efficient caching.
     """
-    root = path.resolve()
-    for p in chain([root], root.parents):
-        pyproject_toml = p / _PYPROJECT_TOML
-        if pyproject_toml.exists():
-            return pyproject_toml
-    msg = f"Could not find {_PYPROJECT_TOML} file within path hierarchy"
-    raise FileNotFoundError(msg)
+    if (result := path / _PYPROJECT_TOML).exists():
+        return result
+
+    if path == path.parent:  # Exit recursion
+        msg = f"Could not find {_PYPROJECT_TOML} file within path hierarchy"
+        raise FileNotFoundError(msg)
+
+    return get_pyproject_toml(path.parent)
 
 
 @dataclass(frozen=True)

--- a/src/tests/check-dependencies.toml
+++ b/src/tests/check-dependencies.toml
@@ -18,3 +18,4 @@
     "tests_main",
  ]
  "includes" = ["./check-dependencies.toml"]
+ provides = {"pytest" = "_pytest"}

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -4,6 +4,8 @@ from pathlib import Path
 
 import pytest
 
+from check_dependencies.pyproject_toml import get_pyproject_toml
+
 DATA = (Path(__file__).parent / "data").resolve()
 SRC_MODULE = DATA / "src"
 SRC = (SRC_MODULE / "src.py").as_posix()
@@ -20,6 +22,16 @@ UV_LEGACY_EXTRA = DATA / "pyproject_uv_legacy_extra.toml"
 PYPROJECT_CFG = DATA / "pyproject_cfg.toml"
 PYPROJECT_EMPTY = DATA / "pyproject_empty.toml"
 PYPROJECT_PROVIDES = DATA / "pyproject_pep631_provides.toml"
+
+
+@pytest.fixture(autouse=True)
+def clear_pyproject_cache() -> None:
+    """Clear the get_pyproject_toml LRU cache before each test.
+
+    Prevents stale cache entries from tests that patch ``_PYPROJECT_TOML``
+    from polluting subsequent tests.
+    """
+    get_pyproject_toml.cache_clear()
 
 
 @pytest.fixture(params=[PEP631, POETRY, HATCH, UV_LEGACY])

--- a/src/tests/data/pyproject_cfg.toml
+++ b/src/tests/data/pyproject_cfg.toml
@@ -13,7 +13,7 @@ doc = ["test_doctest > 0"]
 
 [tool.check-dependencies]
 known-extra = [
-    "test_extra > 0"
+    "test_extra > 990"
 ]
 known-missing = [
     "test_1", "missing", "missing_class", "missing_def"

--- a/src/tests/test_app_config.py
+++ b/src/tests/test_app_config.py
@@ -1,4 +1,4 @@
-"""Tests for project_config module."""
+"""Tests for app_config module."""
 
 from __future__ import annotations
 

--- a/src/tests/test_app_config.py
+++ b/src/tests/test_app_config.py
@@ -1,0 +1,101 @@
+"""Tests for project_config module."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from check_dependencies.app_config import AppConfig, ProjectConfig
+from check_dependencies.lib import Dependency, Module, Package, Packages
+from check_dependencies.pyproject_toml import PyProjectToml
+
+if TYPE_CHECKING:
+    import ast
+    from collections.abc import Callable, Collection, Iterator, Sequence
+
+
+def app_cfg(
+    known_extra: Sequence[str] = (),
+    known_missing: Sequence[str] = (),
+    provides: Sequence[str] = (),
+    includes: Sequence[Path] = (),
+) -> AppConfig:
+    """Return a default AppConfig for testing."""
+    return AppConfig.from_cli_args(
+        file_names=[Path("src")],
+        known_extra=known_extra,
+        known_missing=known_missing,
+        provides=provides,
+        include_dev=False,
+        verbose=False,
+        show_all=False,
+        includes=includes,
+    )
+
+
+def test_empty_known_extra_cli() -> None:
+    """Test empty known extra from CLI."""
+    assert app_cfg(known_extra=["xx", ""]).known_extra == [Package("xx")]
+
+
+def test_empty_known_missing_cli() -> None:
+    """Test empty known missing from CLI."""
+    assert app_cfg(known_missing=["yy", ""]).known_missing == [Module("yy")]
+
+
+def test_empty_provides_cli() -> None:
+    """Test empty provides from CLI."""
+    assert app_cfg(
+        provides=["xx=xx_", "", "yy=yy1_,yy2_,", "zz="]
+    ).provides._orig_packages == (
+        (Package("xx"), Module("xx_")),
+        (Package("yy"), Module("yy1_")),
+        (Package("yy"), Module("yy2_")),
+    )
+
+
+def project_cfg(
+    known_missing: Collection[Module] = (),
+    defined_dependencies: Collection[Package] = (),
+    allowed_dependencies: Collection[Package] = (),
+    known_extra: Collection[Package] = (),
+    packages: Packages | None = None,
+    src_formatter: Callable[
+        [str, Dependency, Module, ast.AST | None], Iterator[str]
+    ] = lambda *_: iter(()),
+    path: Path = Path("pyproject.toml"),
+) -> ProjectConfig:
+    """Create a  ProjectConfig test instance."""
+    return ProjectConfig(
+        known_missing=known_missing,
+        defined_dependencies=defined_dependencies,
+        allowed_dependencies=allowed_dependencies,
+        known_extra=known_extra,
+        packages=packages or Packages(),
+        src_formatter=src_formatter,
+        path=path,
+    )
+
+
+def test_project_cfg(tmp_path: Path) -> None:
+    """Test ProjectConfig dataclass."""
+    (pyproject_path := tmp_path / "pyproject.toml").write_text(
+        "[project]\n"
+        'dependencies=["dep1=*"]\n'
+        "[tool.check-dependencies]\n"
+        'known-missing = ["missing"]\n'
+        'known-extra = ["extra"]\n'
+        'dependencies = ["dep1", "dep2"]\n'
+        'provides = {dep1 = "mod1", dep2 = "mod2"}\n',
+        "utf-8",
+    )
+    pyproject_cfg = PyProjectToml.for_path(pyproject_path)
+    cfg = ProjectConfig.from_config(app_cfg(provides=["app1=mod1"]), pyproject_cfg)
+    assert cfg.known_missing == {Module("missing")}
+    assert cfg.known_extra == {Package("extra")}
+    assert set(cfg.allowed_dependencies) >= {Package("dep1"), Package("extra")}
+    assert cfg.packages._orig_packages == (
+        (Package("app1"), Module("mod1")),
+        (Package("dep1"), Module("mod1")),
+        (Package("dep2"), Module("mod2")),
+    )

--- a/src/tests/test_lib.py
+++ b/src/tests/test_lib.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import ast
+from pathlib import Path
 
 import pytest
 
@@ -217,8 +218,13 @@ class TestMkSrcFormatter:
     @pytest.mark.parametrize("verbose", [True, False])
     def test_no_show_all_on_status_ok(self, stmt: ast.stmt, verbose: bool) -> None:
         """If the import is expected, we do not show it."""
-        cfg = AppConfig.from_cli_args(
-            file_names=(), verbose=verbose, show_all=False, known_extra=["foo"]
+        cfg = AppConfig(
+            file_names=[Path()],
+            known_extra=[Package("foo")],
+            known_missing=[],
+            provides=Packages([]),
+            verbose=verbose,
+            show_all=False,
         )
         fn = cfg.mk_src_formatter()
         assert not list(fn("src.py", Dependency.OK, Module("foo"), stmt))
@@ -243,13 +249,20 @@ class TestMkSrcFormatter:
         expected: str,
     ) -> None:
         """MkSrcFormatter generic tests."""
-        cfg = AppConfig.from_cli_args(file_names=(), verbose=verbose, show_all=show_all)
+        cfg = AppConfig(
+            file_names=[Path()],
+            known_extra=[],
+            known_missing=[],
+            provides=Packages([]),
+            verbose=verbose,
+            show_all=show_all,
+        )
         fn = cfg.mk_src_formatter()
         assert next(fn("src.py", Dependency(cause), Module("foo"), stmt)) == expected
 
     def test_cache(self, stmt: ast.stmt) -> None:
         """Test the cache mechanism for the formatter."""
-        cfg = AppConfig.from_cli_args(file_names=(), verbose=False)
+        cfg = AppConfig(file_names=[Path()])
         fn = cfg.mk_src_formatter()
         assert list(fn("src.py", Dependency.NA, Module("foo"), stmt))
         assert not list(fn("src.py", Dependency.NA, Module("foo"), stmt))

--- a/src/tests/test_main.py
+++ b/src/tests/test_main.py
@@ -702,6 +702,7 @@ def test_performance_large_project(tmp_path: Path) -> None:
     n_files = 1000
     for i in range(n_files):
         (tmp_path / f"file_{i}.py").write_text("import sys\n")
+    (tmp_path / "pyproject.toml").write_bytes(PYPROJECT_CFG.read_bytes())
     cfg = AppConfig(file_names=[tmp_path])
     start = time.time()
     _ = list(yield_wrong_imports(cfg))

--- a/src/tests/test_main.py
+++ b/src/tests/test_main.py
@@ -19,6 +19,7 @@ from check_dependencies.__main__ import main as cli_main
 from check_dependencies.app_config import AppConfig, ProjectConfig
 from check_dependencies.lib import Dependency, Module, Package, Packages
 from check_dependencies.main import (
+    ERR_NO_PYPROJECT,
     _imports_iter,
     _missing_imports_iter,
     _ProjectRegistry,
@@ -168,12 +169,12 @@ class TestYieldWrongImports:
     """Test collection for the yield wrong imports function."""
 
     @staticmethod
-    def fn(  # pylint: disable=too-many-arguments
+    def fn_ret(  # pylint: disable=too-many-arguments
         overwrite_cfg: Path = POETRY,
         args: Sequence[str] | str = (),
         file_names: Sequence[str] = (SRC,),
         with_comment: bool = False,
-    ) -> list[str]:
+    ) -> tuple[list[str], int]:
         """Call the yield wrong imports function with patched pyproject.toml."""
         if isinstance(args, str):
             args = args.split()
@@ -185,12 +186,29 @@ class TestYieldWrongImports:
         ), patch("sys.argv", ["check-dependencies", *args, *file_names]), patch(
             "check_dependencies.__main__._writer", lines.append
         ):
-            cli_main()
+            exit_status = cli_main()
+
         return [
             line
             for line in lines
             if line != "\n" and (with_comment or not line.startswith("#"))
-        ]
+        ], exit_status
+
+    @classmethod
+    def fn(
+        cls,
+        overwrite_cfg: Path = POETRY,
+        args: Sequence[str] | str = (),
+        file_names: Sequence[str] = (SRC,),
+        with_comment: bool = False,
+    ) -> list[str]:
+        """Call the yield wrong imports function with patched pyproject.toml."""
+        return cls.fn_ret(
+            overwrite_cfg=overwrite_cfg,
+            args=args,
+            file_names=file_names,
+            with_comment=with_comment,
+        )[0]
 
     def test(self, pyproject: Path) -> None:
         """By default, we should only see the missing (and extra) imports."""
@@ -528,6 +546,17 @@ class TestYieldWrongImports:
         assert Package("dep_b") in cfg_b.allowed_dependencies
         assert Package("dep_b") not in cfg_a.allowed_dependencies
         assert Package("dep_a") not in cfg_b.allowed_dependencies
+
+    def test_no_pyproject(self) -> None:
+        """Test that get_pyproject_toml raises without pyproject.toml."""
+        lines, ret_code = self.fn_ret(
+            overwrite_cfg=Path("pyproject.toml"),
+            args=["--verbose"],
+            file_names=["/"],
+            with_comment=True,
+        )
+        assert lines == ["# ALL=False", "# INCLUDE_DEV=False"]
+        assert ret_code == ERR_NO_PYPROJECT
 
 
 @pytest.mark.parametrize(

--- a/src/tests/test_main.py
+++ b/src/tests/test_main.py
@@ -9,18 +9,19 @@ import time
 from importlib.metadata import PackageNotFoundError
 from pathlib import Path
 from textwrap import dedent
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable, Collection
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from check_dependencies.__main__ import _get_version, _MultiSepAction
 from check_dependencies.__main__ import main as cli_main
-from check_dependencies.app_config import AppConfig
+from check_dependencies.app_config import AppConfig, ProjectConfig
 from check_dependencies.lib import Dependency, Module, Package, Packages
 from check_dependencies.main import (
     _imports_iter,
     _missing_imports_iter,
+    _ProjectRegistry,
     yield_wrong_imports,
 )
 from tests.conftest import (
@@ -143,8 +144,9 @@ def test__main__provides_parsing(
     captured: dict[str, Packages] = {}
 
     def _mock_yield(
-        _file_names: object, app_cfg: AppConfig
+        app_cfg: AppConfig,
     ) -> Generator[str, None, int]:
+        # Consume the first pair to get the AppConfig
         captured["provides"] = app_cfg.provides
         yield "_mock_yield"
         return 0
@@ -176,25 +178,23 @@ class TestYieldWrongImports:
         if isinstance(args, str):
             args = args.split()
 
-        stdout = MagicMock()
         lines: list[str] = []
-        stdout.write = lines.append
 
         with patch(
             "check_dependencies.pyproject_toml._PYPROJECT_TOML", overwrite_cfg
         ), patch("sys.argv", ["check-dependencies", *args, *file_names]), patch(
-            "sys.stdout", stdout
+            "check_dependencies.__main__._writer", lines.append
         ):
             cli_main()
-            return [
-                line
-                for line in lines
-                if line != "\n" and (with_comment or not line.startswith("#"))
-            ]
+        return [
+            line
+            for line in lines
+            if line != "\n" and (with_comment or not line.startswith("#"))
+        ]
 
     def test(self, pyproject: Path) -> None:
         """By default, we should only see the missing (and extra) imports."""
-        assert self.fn(overwrite_cfg=pyproject) == [
+        assert self.fn(overwrite_cfg=pyproject, args=[]) == [
             "! missing",
             "! missing_class",
             "! missing_def",
@@ -235,7 +235,7 @@ class TestYieldWrongImports:
         res = self.fn(
             overwrite_cfg=PYPROJECT_EMPTY,
             file_names=[py_file.as_posix()],
-            args=["--verbose", "--extra=extra1"],
+            args=["--verbose", "--extra=extra1", "--missing=missing1"],
         )
 
         assert len(res) == len(expected)
@@ -265,7 +265,6 @@ class TestYieldWrongImports:
             self.fn(overwrite_cfg=pyproject_extra, args="--verbose", with_comment=True)
         ) > {
             "",
-            "# MISSING check_dependencies",
             "### Dependencies in config file not used in application:",
         }
 
@@ -347,7 +346,7 @@ class TestYieldWrongImports:
 
         Include requirements as known-missing - they should not appear in the output.
         """
-        res = self.fn(args="--missing=missing,test_1")
+        res = self.fn(args="--missing=missing,test_1", with_comment=True)
         assert res == ["! missing_class", "! missing_def"]
 
     def test_verbose(self) -> None:
@@ -421,7 +420,7 @@ class TestYieldWrongImports:
 
     def test_no_fail_on_missing_source(self) -> None:
         """Test that we do not fail if the source file is missing."""
-        res = AppConfig.from_cli_args(
+        cfg = AppConfig.from_cli_args(
             file_names=[Path("nonexistent.py")],
             known_extra=[],
             known_missing=[],
@@ -430,7 +429,8 @@ class TestYieldWrongImports:
             verbose=False,
             show_all=False,
         )
-        assert res
+
+        assert cfg
 
     def test_unicode_imports(self) -> None:
         """Test for Unicode module names."""
@@ -478,6 +478,57 @@ class TestYieldWrongImports:
         res = [line for line in res if line.startswith("# PROVIDES")]
         assert "# PROVIDES pytest -> [_pytest, py]" in res
 
+    def test_multi_project_support(self, tmp_path: Path) -> None:
+        """Files in different project trees each get their own AppConfig.
+
+        Two sub-directories each contain a pyproject.toml with distinct
+        dependencies.  from_cli_args should yield a different AppConfig
+        (with a different pyproject_file) for a file in each project.
+        """
+        proj_a = tmp_path / "proj_a"
+        proj_b = tmp_path / "proj_b"
+        proj_a.mkdir()
+        proj_b.mkdir()
+
+        (proj_a / "pyproject.toml").write_text(
+            dedent("""\
+            [project]
+            name = "proj-a"
+            dependencies = ["dep_a"]
+            """),
+            "utf-8",
+        )
+        (proj_b / "pyproject.toml").write_text(
+            dedent("""\
+            [project]
+            name = "proj-b"
+            dependencies = ["dep_b"]
+            """),
+            "utf-8",
+        )
+
+        file_a = proj_a / "mod_a.py"
+        file_b = proj_b / "mod_b.py"
+        file_a.write_text("import dep_a\n", "utf-8")
+        file_b.write_text("import dep_b\n", "utf-8")
+
+        app_cfg = AppConfig.from_cli_args(file_names=[file_a, file_b])
+        registry = _ProjectRegistry(app_cfg)
+        cfg_a, _ = registry.get(proj_a / "foo.py")
+        cfg_a2, _ = registry.get(
+            proj_a / "bar.py"
+        )  # same project, should get same config
+        cfg_b, _ = registry.get(proj_b / "foo.py")
+
+        assert cfg_a is not cfg_b
+        assert cfg_a is cfg_a2
+        assert cfg_a.path == proj_a / "pyproject.toml"
+        assert cfg_b.path == proj_b / "pyproject.toml"
+        assert Package("dep_a") in cfg_a.allowed_dependencies
+        assert Package("dep_b") in cfg_b.allowed_dependencies
+        assert Package("dep_b") not in cfg_a.allowed_dependencies
+        assert Package("dep_a") not in cfg_b.allowed_dependencies
+
 
 @pytest.mark.parametrize(
     "stmt, expected",
@@ -492,12 +543,33 @@ def test_imports_iter(stmt: str, expected: list[str]) -> None:
     assert [x.name for x, _ in _imports_iter(parsed.body)] == expected
 
 
+def project_cfg(
+    known_missing: Collection[Module] = (),
+    defined_dependencies: Collection[Package] = (),
+    allowed_dependencies: Collection[Package] = (),
+    known_extra: Collection[Package] = (),
+    packages: Packages | None = None,
+    src_formatter: Callable = lambda *_: iter([]),
+    path: Path = Path(),
+) -> ProjectConfig:
+    """Create a ProjectConfig with default values."""
+    return ProjectConfig(
+        known_missing=known_missing,
+        defined_dependencies=defined_dependencies,
+        allowed_dependencies=allowed_dependencies,
+        known_extra=known_extra,
+        packages=packages or Packages([]),
+        src_formatter=src_formatter,
+        path=path,
+    )
+
+
 def test_missing_import_iter_silent_on_invalid_python_code() -> None:
     """Test that missing imports iterator catches invalid Python code."""
     my_path = MagicMock()
     my_path.as_posix.return_value = "dummy.py"
     my_path.read_bytes.return_value = b"()foo"
-    res = list(_missing_imports_iter(my_path, set(), Packages([])))
+    res = list(_missing_imports_iter(my_path, project_cfg()))
     assert len(res) == 1
     status, module, _ = res[0]
     assert status == Dependency.FILE_ERROR
@@ -510,7 +582,7 @@ def test_missing_imports_iter_non_utf8_encoding(tmp_path: Path) -> None:
     # Write a latin-1 encoded file with an encoding cookie and an import
     content = "# -*- coding: latin-1 -*-\nimport os\nx = 'caf\xe9'\n"
     py_file.write_bytes(content.encode("latin-1"))
-    result = list(_missing_imports_iter(py_file, set(), Packages([])))
+    result = list(_missing_imports_iter(py_file, project_cfg()))
     assert [m.name for _, m, _ in result] == ["os"]
 
 
@@ -518,7 +590,10 @@ def test_missing_imports_iter() -> None:
     """Test the missing import iterator."""
     res = list(
         _missing_imports_iter(
-            Path(SRC), Package.set({"test_0", "test_1", "extra"}), Packages([])
+            Path(SRC),
+            project_cfg(
+                allowed_dependencies=Package.set({"test_0", "test_1", "extra"})
+            ),
         )
     )
     assert {c for c, _, _ in res} == {Dependency.NA, Dependency.OK}
@@ -545,7 +620,17 @@ def test_missing_imports_iter() -> None:
 )
 def test_mk_unused_formatter(verbose: bool, expected: str) -> None:
     """Test the unused formatter."""
-    cfg = AppConfig.from_cli_args(file_names=[DATA], verbose=verbose)
+    cfg = AppConfig.from_cli_args(
+        file_names=[DATA],
+        known_extra=[],
+        known_missing=[],
+        provides=[],
+        include_dev=False,
+        verbose=verbose,
+        show_all=False,
+        includes=[],
+        provides_from_venv=None,
+    )
     assert list(cfg.unused_fmt("foo")) == [expected]
 
 
@@ -589,7 +674,11 @@ import sys
 """
     py_file.write_text(content, encoding="utf-8")
 
-    result = list(_missing_imports_iter(py_file, Package.set({"sys"}), Packages([])))
+    result = list(
+        _missing_imports_iter(
+            py_file, project_cfg(allowed_dependencies=Package.set({"sys"}))
+        )
+    )
 
     # Extract module names
     modules = [m.name for _, m, _ in result]
@@ -613,14 +702,9 @@ def test_performance_large_project(tmp_path: Path) -> None:
     n_files = 1000
     for i in range(n_files):
         (tmp_path / f"file_{i}.py").write_text("import sys\n")
-    cfg = AppConfig(
-        dependencies=[],
-        known_extra=[],
-        known_missing=[],
-        provides=Packages([]),
-    )
+    cfg = AppConfig(file_names=[tmp_path])
     start = time.time()
-    _ = list(yield_wrong_imports([tmp_path.as_posix()], cfg))
+    _ = list(yield_wrong_imports(cfg))
     duration = time.time() - start
 
     assert duration < max_duration_per_file * n_files

--- a/src/tests/test_main.py
+++ b/src/tests/test_main.py
@@ -264,8 +264,8 @@ class TestYieldWrongImports:
         assert set(
             self.fn(overwrite_cfg=pyproject_extra, args="--verbose", with_comment=True)
         ) > {
-            "",
-            "### Dependencies in config file not used in application:",
+            "# INCLUDE_DEV=False",
+            "# Dependencies in config file not used in application:",
         }
 
     def test_extra_requirements_as_cfg(self) -> None:

--- a/src/tests/test_pyproject_toml.py
+++ b/src/tests/test_pyproject_toml.py
@@ -14,13 +14,7 @@ from check_dependencies.pyproject_toml import (
     _nested_item,
     get_pyproject_toml,
 )
-from tests.conftest import (
-    HATCH,
-    PEP631,
-    POETRY,
-    PYPROJECT_PROVIDES,
-    UV_LEGACY,
-)
+from tests.conftest import HATCH, PEP631, POETRY, PYPROJECT_PROVIDES, UV_LEGACY
 
 try:
     import tomllib  # ty:ignore[unresolved-import]
@@ -104,6 +98,53 @@ class TestPyProjectToml:
             includes_cfg=[],
         )
         assert cfg.provides == {(Package(expected), Module("some_import"))}
+
+    def test_includes(self, tmp_path: Path) -> None:
+        """Test that includes are processed correctly."""
+        a = tmp_path / "a.toml"
+        b = tmp_path / "b.toml"
+        a.write_text(
+            "[tool.check-dependencies]\n"
+            'known-missing = ["mod_a"]\n'
+            'known-extra = ["extra_a"]\n'
+            'includes = ["b.toml"]\n'
+            'provides = {extra_a = "mod_a"}\n',
+            "utf-8",
+        )
+        b.write_text(
+            "[tool.check-dependencies]\n"
+            'known-missing = ["mod_b"]\n'
+            'known-extra = ["extra_b"]\n'
+            'includes = ["c.toml"]\n'
+            'provides = {extra_b = "mod_b"}\n',
+            "utf-8",
+        )
+        (tmp_path / "c.toml").write_text(
+            "[tool.check-dependencies]\n"
+            'known-missing = ["mod_c"]\n'
+            'known-extra = ["extra_c"]\n'
+            "[tool.check-dependencies.provides]\n"
+            'extra_c = "mod_c"\n'
+            'extra_a = "mod_ac"\n',
+            "utf-8",
+        )
+        result = PyProjectToml.for_path(a)
+        assert set(result.known_missing) == {
+            Module("mod_a"),
+            Module("mod_b"),
+            Module("mod_c"),
+        }
+        assert set(result.known_extra) == {
+            Package("extra_a"),
+            Package("extra_b"),
+            Package("extra_c"),
+        }
+        assert set(result.provides) == {
+            (Package("extra_a"), Module("mod_a")),
+            (Package("extra_a"), Module("mod_ac")),
+            (Package("extra_b"), Module("mod_b")),
+            (Package("extra_c"), Module("mod_c")),
+        }
 
 
 class TestNestedItem:

--- a/src/tests/test_pyproject_toml.py
+++ b/src/tests/test_pyproject_toml.py
@@ -9,9 +9,10 @@ import pytest
 
 from check_dependencies.lib import Module, Package
 from check_dependencies.pyproject_toml import (
+    NoPyProjectFileError,
     PyProjectToml,
     _nested_item,
-    get_pyproject_toml, NoPyProjectFile,
+    get_pyproject_toml,
 )
 from tests.conftest import (
     HATCH,
@@ -178,5 +179,5 @@ class TestGetPyProjectToml:
 
     def test_no_pyproject(self) -> None:
         """Test that get_pyproject_toml raises without pyproject.toml."""
-        with pytest.raises(NoPyProjectFile):
+        with pytest.raises(NoPyProjectFileError):
             get_pyproject_toml(Path("/"))

--- a/src/tests/test_pyproject_toml.py
+++ b/src/tests/test_pyproject_toml.py
@@ -218,7 +218,9 @@ class TestGetPyProjectToml:
         pyproject.write_text("[tool.check-dependencies]\n", "utf-8")
         assert get_pyproject_toml(tmp_path) == pyproject
 
-    def test_no_pyproject(self) -> None:
-        """Test that get_pyproject_toml raises without pyproject.toml."""
+    def test_no_pyproject(self, tmp_path: Path) -> None:
+        """Test that get_pyproject_toml raises when no pyproject.toml exists."""
+        subdir = tmp_path / "no_project"
+        subdir.mkdir()
         with pytest.raises(NoPyProjectFileError):
-            get_pyproject_toml(Path("/"))
+            get_pyproject_toml(subdir)

--- a/src/tests/test_pyproject_toml.py
+++ b/src/tests/test_pyproject_toml.py
@@ -128,6 +128,45 @@ class TestNestedItem:
             _nested_item(prj.cfg, "a", str)
 
 
+class TestPyProjectTomlCircularIncludes:
+    """Test that circular includes in PyProjectToml are handled correctly."""
+
+    def test_circular_include_no_duplicate(self, tmp_path: Path) -> None:
+        """Circular includes (A→B→A) must not duplicate config values from A."""
+        a = tmp_path / "a.toml"
+        b = tmp_path / "b.toml"
+        a.write_text(
+            "[tool.check-dependencies]\n"
+            'known-missing = ["mod_a"]\n'
+            'includes = ["b.toml"]\n',
+            "utf-8",
+        )
+        b.write_text(
+            "[tool.check-dependencies]\n"
+            'known-missing = ["mod_b"]\n'
+            'includes = ["a.toml"]\n',
+            "utf-8",
+        )
+        result = PyProjectToml.for_path(a)
+        # mod_a should appear exactly once; mod_b exactly once
+        known = list(result.known_missing)
+        assert known.count(Module("mod_a")) == 1
+        assert known.count(Module("mod_b")) == 1
+
+    def test_self_referential_include(self, tmp_path: Path) -> None:
+        """A self-referential include must not recurse infinitely or duplicate."""
+        a = tmp_path / "a.toml"
+        a.write_text(
+            "[tool.check-dependencies]\n"
+            'known-missing = ["mod_a"]\n'
+            'includes = ["a.toml"]\n',
+            "utf-8",
+        )
+        result = PyProjectToml.for_path(a)
+        known = list(result.known_missing)
+        assert known.count(Module("mod_a")) == 1
+
+
 class TestGetPyProjectToml:
     """Test suite for the get_pyproject_toml function."""
 

--- a/src/tests/test_pyproject_toml.py
+++ b/src/tests/test_pyproject_toml.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import sys
 from pathlib import Path
 from typing import TypeVar
 
@@ -11,8 +10,8 @@ import pytest
 from check_dependencies.lib import Module, Package
 from check_dependencies.pyproject_toml import (
     PyProjectToml,
-    _get_pyproject_path,
     _nested_item,
+    get_pyproject_toml,
 )
 from tests.conftest import (
     HATCH,
@@ -37,6 +36,7 @@ class TestPyProjectToml:
             cfg=tomllib.loads(path.read_text("utf-8")),
             path=path,
             include_dev=include_dev,
+            includes_cfg=[],
         )
 
     @pytest.mark.parametrize(
@@ -65,7 +65,10 @@ class TestPyProjectToml:
     def test_unsupported_dependencies(self) -> None:
         """Test unsupported dependencies in pyproject.toml."""
         cfg = PyProjectToml(
-            cfg={"project": {"name": "test-project"}}, path=Path(), include_dev=False
+            cfg={"project": {"name": "test-project"}},
+            path=Path(),
+            include_dev=False,
+            includes_cfg=[],
         )
         with pytest.raises(ValueError, match="No dependency management found"):
             _ = cfg.dependencies
@@ -73,12 +76,12 @@ class TestPyProjectToml:
     def test_provides_empty(self) -> None:
         """Test that provides returns an empty dict when not configured."""
         cfg = self.cfg(PEP631)
-        assert cfg.provides == []
+        assert cfg.provides == set()
 
     def test_provides(self) -> None:
         """Test that provides returns the correct mapping."""
         cfg = self.cfg(PYPROJECT_PROVIDES)
-        assert cfg.provides == [(Package("test_alias_pkg"), Module("test_1"))]
+        assert cfg.provides == {(Package("test_alias_pkg"), Module("test_1"))}
 
     @pytest.mark.parametrize(
         "raw, expected",
@@ -97,16 +100,9 @@ class TestPyProjectToml:
             cfg={"tool": {"check-dependencies": {"provides": {raw: "some_import"}}}},
             path=Path("dummy"),
             include_dev=False,
+            includes_cfg=[],
         )
-        assert cfg.provides == [(Package(expected), Module("some_import"))]
-
-    @pytest.mark.skipif(sys.platform != "win32", reason="Windows-specific test")
-    def test_fails_on_different_paths(self) -> None:
-        """Test that PyProjectToml raises when initialized with different paths."""
-        with pytest.raises(
-            ValueError, match=r"Error finding common path for.*C:.test.*D:.test"
-        ):
-            PyProjectToml.for_paths([Path("C:/test"), Path("D:/test")])
+        assert cfg.provides == {(Package(expected), Module("some_import"))}
 
 
 class TestNestedItem:
@@ -120,26 +116,28 @@ class TestNestedItem:
     )
     def test_nested_item(self, key: str, type_: type[_T], expected: _T) -> None:
         """Test nested item."""
-        prj = PyProjectToml(cfg={"a": {"b": {"c": 1, "d": 2}}}, path=Path())
+        prj = PyProjectToml(
+            cfg={"a": {"b": {"c": 1, "d": 2}}}, path=Path(), includes_cfg=[]
+        )
         assert _nested_item(prj.cfg, key, type_) == expected
 
     def test_raise_wrong_type(self) -> None:
         """Raise wrong type."""
-        prj = PyProjectToml(cfg={"a": 1}, path=Path())
+        prj = PyProjectToml(cfg={"a": 1}, path=Path(), includes_cfg=[])
         with pytest.raises(TypeError):
             _nested_item(prj.cfg, "a", str)
 
 
-class TestGetPyProjectPath:
-    """Test suite for the get_pyproject_path function."""
+class TestGetPyProjectToml:
+    """Test suite for the get_pyproject_toml function."""
 
     def test_find_pyproject(self, tmp_path: Path) -> None:
-        """Test that get_pyproject_path finds the pyproject.toml file."""
+        """Test that get_pyproject_toml finds the pyproject.toml file."""
         pyproject = tmp_path / "pyproject.toml"
         pyproject.write_text("[tool.check-dependencies]\n", "utf-8")
-        assert _get_pyproject_path(tmp_path) == pyproject
+        assert get_pyproject_toml(tmp_path) == pyproject
 
     def test_no_pyproject(self) -> None:
-        """Test that get_pyproject_path raises without pyproject.toml."""
+        """Test that get_pyproject_toml raises without pyproject.toml."""
         with pytest.raises(FileNotFoundError):
-            _get_pyproject_path(Path("/"))
+            get_pyproject_toml(Path("/"))

--- a/src/tests/test_pyproject_toml.py
+++ b/src/tests/test_pyproject_toml.py
@@ -11,7 +11,7 @@ from check_dependencies.lib import Module, Package
 from check_dependencies.pyproject_toml import (
     PyProjectToml,
     _nested_item,
-    get_pyproject_toml,
+    get_pyproject_toml, NoPyProjectFile,
 )
 from tests.conftest import (
     HATCH,
@@ -178,5 +178,5 @@ class TestGetPyProjectToml:
 
     def test_no_pyproject(self) -> None:
         """Test that get_pyproject_toml raises without pyproject.toml."""
-        with pytest.raises(FileNotFoundError):
+        with pytest.raises(NoPyProjectFile):
             get_pyproject_toml(Path("/"))


### PR DESCRIPTION
# PR Overview
This PR updates check-dependencies to select the appropriate pyproject.toml based on each analyzed source file’s location (multi-project/monorepo support), and adjusts configuration parsing and tests accordingly.

# Changes
- Add per-project configuration resolution by locating the nearest pyproject.toml per scanned file (with caching) and aggregating results per project.
- Rework config/include parsing so included TOML configs can contribute known-missing, known-extra, and provides.
- Update CLI output plumbing and expand/adjust the test suite for the new multi-project behavior.