### PR TITLE
TEST: Enhance pyproject.toml detection tests for missing files

### DIFF
--- a/src/tests/test_main.py
+++ b/src/tests/test_main.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import ast
 import sys
+import textwrap
 import time
 from importlib.metadata import PackageNotFoundError
 from pathlib import Path
@@ -14,6 +15,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+import check_dependencies.pyproject_toml
 from check_dependencies.__main__ import _get_version, _MultiSepAction
 from check_dependencies.__main__ import main as cli_main
 from check_dependencies.app_config import AppConfig, ProjectConfig
@@ -547,8 +549,17 @@ class TestYieldWrongImports:
         assert Package("dep_b") not in cfg_a.allowed_dependencies
         assert Package("dep_a") not in cfg_b.allowed_dependencies
 
-    def test_no_pyproject(self) -> None:
+    def test_no_pyproject(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Test that get_pyproject_toml raises without pyproject.toml."""
+        subdir = tmp_path / "no_project"
+        subdir.mkdir()
+        monkeypatch.setattr(
+            check_dependencies.pyproject_toml,
+            "_PYPROJECT_TOML",
+            Path(subdir / "/non-existent-pyproject.toml"),
+        )
         lines, ret_code = self.fn_ret(
             overwrite_cfg=Path("pyproject.toml"),
             args=["--verbose"],
@@ -676,6 +687,7 @@ def test_mk_unused_formatter(verbose: bool, expected: str) -> None:
         ("import os\nö = 1", ["os"]),
         # Mixed ASCII and Unicode
         ("import foo_ö", ["foo_ö"]),
+        ("import ä, ö, café, 日本語, Москва", ["ä", "ö", "café", "日本語", "Москва"]),
     ],
 )
 def test_imports_iter_unicode(stmt: str, expected: list[str]) -> None:
@@ -696,11 +708,12 @@ def test_missing_imports_iter_unicode_file(tmp_path: Path) -> None:
     (even though such imports would fail at runtime).
     """
     py_file = tmp_path / "unicode_imports.py"
-    content = """# -*- coding: utf-8 -*-
-import ö
-from café import something
-import sys
-"""
+    content = textwrap.dedent("""\
+        # -*- coding: utf-8 -*-
+        import ö
+        from café import something
+        import sys
+        """)
     py_file.write_text(content, encoding="utf-8")
 
     result = list(

--- a/src/tests/test_pyproject_toml.py
+++ b/src/tests/test_pyproject_toml.py
@@ -7,6 +7,7 @@ from typing import TypeVar
 
 import pytest
 
+from check_dependencies import pyproject_toml
 from check_dependencies.lib import Module, Package
 from check_dependencies.pyproject_toml import (
     NoPyProjectFileError,
@@ -14,7 +15,13 @@ from check_dependencies.pyproject_toml import (
     _nested_item,
     get_pyproject_toml,
 )
-from tests.conftest import HATCH, PEP631, POETRY, PYPROJECT_PROVIDES, UV_LEGACY
+from tests.conftest import (
+    HATCH,
+    PEP631,
+    POETRY,
+    PYPROJECT_PROVIDES,
+    UV_LEGACY,
+)
 
 try:
     import tomllib  # ty:ignore[unresolved-import]
@@ -218,9 +225,16 @@ class TestGetPyProjectToml:
         pyproject.write_text("[tool.check-dependencies]\n", "utf-8")
         assert get_pyproject_toml(tmp_path) == pyproject
 
-    def test_no_pyproject(self, tmp_path: Path) -> None:
+    def test_no_pyproject(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Test that get_pyproject_toml raises when no pyproject.toml exists."""
         subdir = tmp_path / "no_project"
         subdir.mkdir()
+        monkeypatch.setattr(
+            pyproject_toml,
+            "_PYPROJECT_TOML",
+            Path(subdir / "/non-existent-pyproject.toml"),
+        )
         with pytest.raises(NoPyProjectFileError):
             get_pyproject_toml(subdir)


### PR DESCRIPTION
This pull request updates the test suite to improve handling of missing `pyproject.toml` files and enhances Unicode import handling in test cases. The changes mainly focus on increasing test coverage for edge cases and improving the robustness of the test code.

**Test improvements for missing `pyproject.toml` handling:**

* Updated `test_no_pyproject` methods in both `test_main.py` and `test_pyproject_toml.py` to use `monkeypatch` for simulating the absence of a `pyproject.toml` file, making the tests more reliable and isolated. [[1]](diffhunk://#diff-24e5bb3549f1f9cf8747aa45c2019439c770d4acd7e36ee319efa978b3c859cbL550-R562) [[2]](diffhunk://#diff-51f7bd014c3f8a4b0f363f8f2476bb9765b4f59d639f1083e4fbfb78b90962c7L221-R238)

**Unicode import handling in tests:**

* Added a new test case to `test_imports_iter_unicode` to cover multiple Unicode identifiers in a single import statement, ensuring better coverage for non-ASCII imports.
* Updated the `test_missing_imports_iter_unicode_file` test to use `textwrap.dedent` for consistent formatting of multi-line Unicode import statements.

**Test imports and code organization:**

* Added or reorganized imports in `test_main.py` and `test_pyproject_toml.py` to directly import the `pyproject_toml` module, enabling easier patching and clarity in test code. [[1]](diffhunk://#diff-24e5bb3549f1f9cf8747aa45c2019439c770d4acd7e36ee319efa978b3c859cbR18) [[2]](diffhunk://#diff-51f7bd014c3f8a4b0f363f8f2476bb9765b4f59d639f1083e4fbfb78b90962c7R10-R24)
* Imported `textwrap` in `test_main.py` to support dedenting of multi-line strings in tests.