### PR TITLE
Add icon and color to github action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: check-dependencies
-description: Run check-dependencies with AppConfig-derived parameters.
+description: "Check Python source dependencies against pyproject.toml."
 
 branding:
   icon: check-circle

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,10 @@
 name: check-dependencies
 description: Run check-dependencies with AppConfig-derived parameters.
 
+branding:
+  icon: check-circle
+  color: green
+
 inputs:
   file-names:
     description: |


### PR DESCRIPTION
This pull request adds branding information to the `check-dependencies` GitHub Action. The branding specifies an icon and color, which will improve the visual appearance of the action in the GitHub Actions UI.