### PR TITLE
FIX: Prevent GitHub release creation if it already exists

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -145,11 +145,15 @@ jobs:
       - name: Create GitHub Release
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        run: >-
-          gh release create
-          '${{ github.ref_name }}'
-          --repo '${{ github.repository }}'
-          --notes ""
+        run: |
+          if gh release view '${{ github.ref_name }}' --repo '${{ github.repository }}' >/dev/null 2>&1; then
+            echo "Release '${{ github.ref_name }}' already exists; skipping creation."
+          else
+            gh release create \
+              '${{ github.ref_name }}' \
+              --repo '${{ github.repository }}' \
+              --notes ""
+          fi
       - name: Upload artifact signatures to GitHub Release
         env:
           GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
# Pull request overview
This PR updates the release-publishing portion of the CI workflow to avoid failing when a GitHub Release for the current tag already exists (e.g., on workflow re-runs), while still proceeding to upload the built artifacts/signatures.

## Changes:

Add an existence check (gh release view) before attempting gh release create.
Skip release creation with a clear log message when the release already exists.