### PR TITLE
Bug/91 typeshed is not defined as an internal module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Upcoming
 - **CHANGE:** Bump Python minimum runtime version to 3.9.
 - **FIX:** Remove non-builtin modules from Python 3.9 builtins.
+- **FIX:** Add _typeshed typing only stdlib module to builtin_module.
 
 ### [1.6.0]
 - **ADD:** Support namespaces for dependency matching.

--- a/src/check_dependencies/builtin_module.py
+++ b/src/check_dependencies/builtin_module.py
@@ -5,13 +5,19 @@ from __future__ import annotations
 import sys
 
 BUILTINS: frozenset[str]
+_EXTRA_MODULES = frozenset(
+    {
+        "_typeshed"  # Part of stdlib, but not available at runtime.
+    }
+)
 
 if sys.version_info >= (3, 10):
-    BUILTINS = frozenset(sys.stdlib_module_names)  # pylint: disable=no-member
+    BUILTINS = frozenset(sys.stdlib_module_names).union(_EXTRA_MODULES)  # pylint: disable=no-member
 else:
     # Use the list of builtins from Python 3.9
     BUILTINS = frozenset(  # pragma: no cover
-        [
+        {
+            *_EXTRA_MODULES,
             "__future__",
             "_abc",
             "_aix_support",
@@ -321,5 +327,5 @@ else:
             "zipimport",
             "zlib",
             "zoneinfo",
-        ],
+        },
     )

--- a/tests/test_builtin_modules.py
+++ b/tests/test_builtin_modules.py
@@ -15,9 +15,17 @@ def test_is_frozenset():
     assert isinstance(builtin_module.BUILTINS, frozenset)
 
 
-def test_contains_future():
+@pytest.mark.parametrize(
+    "module_name",
+    [
+        "sys",
+        "__future__",
+        "_typeshed",
+    ],
+)
+def test_contains_future(module_name: str):
     """Test a single sample module."""
-    assert "__future__" in builtin_module.BUILTINS
+    assert module_name in builtin_module.BUILTINS
 
 
 @pytest.mark.parametrize(
@@ -28,9 +36,9 @@ def test_contains_future():
 def test_does_not_contain_extra_module(
     module: str, version: tuple[int, int], monkeypatch: pytest.MonkeyPatch
 ):
+    """Test that a module that is not builtin is not in the set."""
     if version >= (3, 10) and sys.version_info < (3, 10):
         pytest.skip("Python version is too low for this test")
-    """Test that a module that is not builtin is not in the set."""
     monkeypatch.setattr("sys.version_info", version)
     monkeypatch.delitem(sys.modules, "check_dependencies.builtin_module", raising=False)
     bmod = import_module("check_dependencies.builtin_module")


### PR DESCRIPTION
That's interesting - _typeshed is  special module as it' not available at runtime - so it's not part of the sys.internal_module_names.