### PR TITLE
Release v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### [2.0.0]
 - **CHANGE:** Remove deprecated `--all` option from CLI. Use `--output-format full` instead.
-- **CHANGE**: Optional dependencies are also checked  now. They can be configured in the pyproject.toml file 
+- **CHANGE:** Optional dependencies are also checked now. They can be configured in the `pyproject.toml` file
     under `[tool.check-dependencies.optional-dependencies]` with a mapping of dependency groups to path prefixes.
 
 ### [1.8.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Planned
 
 ### Upcoming
+
+### [2.0.0]
 - **CHANGE:** Remove deprecated `--all` option from CLI. Use `--output-format full` instead.
 - **CHANGE**: Optional dependencies are also checked  now. They can be configured in the pyproject.toml file 
     under `[tool.check-dependencies.optional-dependencies]` with a mapping of dependency groups to path prefixes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ authors = [
 license = { text = "MIT" }
 requires-python = ">=3.10"
 name = "check-dependencies"
-version = "1.8.0"
+version = "2.0.0"
 readme = "README.md"
 description = "Check dependencies of a python project against pyproject.toml requirements"
 keywords = ["packaging", "development", "requirements", "dependencies"]


### PR DESCRIPTION
- **CHANGE:** Remove deprecated `--all` option from CLI. Use `--output-format full` instead.
- **CHANGE**: Optional dependencies are also checked  now. They can be configured in the pyproject.toml file under `[tool.check-dependencies.optional-dependencies]` with a mapping of dependency groups to path prefixes.